### PR TITLE
Add integration push/pull workflow with status tracking

### DIFF
--- a/Blueprint.Api.Client/Blueprint.Api.Contracts.cs
+++ b/Blueprint.Api.Client/Blueprint.Api.Contracts.cs
@@ -9709,21 +9709,6 @@ namespace Blueprint.Api.Client
         [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]   
         public string Email { get; set; }
 
-        [System.Text.Json.Serialization.JsonPropertyName("playerTeamId")]
-
-        [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]   
-        public System.Guid? PlayerTeamId { get; set; }
-
-        [System.Text.Json.Serialization.JsonPropertyName("galleryTeamId")]
-
-        [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]   
-        public System.Guid? GalleryTeamId { get; set; }
-
-        [System.Text.Json.Serialization.JsonPropertyName("citeTeamId")]
-
-        [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]   
-        public System.Guid? CiteTeamId { get; set; }
-
         [System.Text.Json.Serialization.JsonPropertyName("canTeamLeaderInvite")]
 
         [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]   

--- a/Blueprint.Api.Data/Enumerations.cs
+++ b/Blueprint.Api.Data/Enumerations.cs
@@ -9,6 +9,8 @@ namespace Blueprint.Api.Data.Enumerations
         Entered = 10,
         Approved = 20,
         Complete = 30,
+        Pushing = 35,
+        Pulling = 36,
         Deployed = 40,
         Archived = 50
     }

--- a/Blueprint.Api.Data/Models/Msel.cs
+++ b/Blueprint.Api.Data/Models/Msel.cs
@@ -17,6 +17,7 @@ namespace Blueprint.Api.Data.Models
         public string Name { get; set; }
         public string Description { get; set; }
         public MselItemStatus Status { get; set; }
+        public string IntegrationStatus { get; set; }
         public bool UsePlayer { get; set; }
         public Guid? PlayerViewId { get; set; }
         public IntegrationType PlayerIntegrationType { get; set; }

--- a/Blueprint.Api.Data/Models/Team.cs
+++ b/Blueprint.Api.Data/Models/Team.cs
@@ -20,9 +20,6 @@ namespace Blueprint.Api.Data.Models
         public Guid? CiteTeamTypeId { get; set; }
         public string CiteTeamTypeName { get; set; }
         public string Email { get; set; }
-        public Guid? PlayerTeamId { get; set; }
-        public Guid? GalleryTeamId { get; set; }
-        public Guid? CiteTeamId { get; set; }
         public bool canTeamLeaderInvite { get; set; }
         public bool canTeamMemberInvite { get; set; }
         public ICollection<TeamUserEntity> TeamUsers { get; set; } = new List<TeamUserEntity>();

--- a/Blueprint.Api.Migrations.PostgreSQL/Migrations/20260402142340_AddMselIntegrationStatus.Designer.cs
+++ b/Blueprint.Api.Migrations.PostgreSQL/Migrations/20260402142340_AddMselIntegrationStatus.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Blueprint.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Blueprint.Api.Migrations.PostgreSQL.Migrations
 {
     [DbContext(typeof(BlueprintContext))]
-    partial class BlueprintContextModelSnapshot : ModelSnapshot
+    [Migration("20260402142340_AddMselIntegrationStatus")]
+    partial class AddMselIntegrationStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Blueprint.Api.Migrations.PostgreSQL/Migrations/20260402142340_AddMselIntegrationStatus.cs
+++ b/Blueprint.Api.Migrations.PostgreSQL/Migrations/20260402142340_AddMselIntegrationStatus.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Blueprint.Api.Migrations.PostgreSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMselIntegrationStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "integration_status",
+                table: "msels",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "integration_status",
+                table: "msels");
+        }
+    }
+}

--- a/Blueprint.Api.Migrations.PostgreSQL/Migrations/20260407140135_RemoveTeamIntegrationIds.Designer.cs
+++ b/Blueprint.Api.Migrations.PostgreSQL/Migrations/20260407140135_RemoveTeamIntegrationIds.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Blueprint.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Blueprint.Api.Migrations.PostgreSQL.Migrations
 {
     [DbContext(typeof(BlueprintContext))]
-    partial class BlueprintContextModelSnapshot : ModelSnapshot
+    [Migration("20260407140135_RemoveTeamIntegrationIds")]
+    partial class RemoveTeamIntegrationIds
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Blueprint.Api.Migrations.PostgreSQL/Migrations/20260407140135_RemoveTeamIntegrationIds.cs
+++ b/Blueprint.Api.Migrations.PostgreSQL/Migrations/20260407140135_RemoveTeamIntegrationIds.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Blueprint.Api.Migrations.PostgreSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveTeamIntegrationIds : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "cite_team_id",
+                table: "teams");
+
+            migrationBuilder.DropColumn(
+                name: "gallery_team_id",
+                table: "teams");
+
+            migrationBuilder.DropColumn(
+                name: "player_team_id",
+                table: "teams");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "cite_team_id",
+                table: "teams",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "gallery_team_id",
+                table: "teams",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "player_team_id",
+                table: "teams",
+                type: "uuid",
+                nullable: true);
+        }
+    }
+}

--- a/Blueprint.Api/Blueprint.Api.csproj
+++ b/Blueprint.Api/Blueprint.Api.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="10.105.0" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageReference Include="Player.Api.Client" Version="3.2.0" />
-    <PackageReference Include="steamfitter.api.client" Version="1.7.0" />
+    <PackageReference Include="Steamfitter.Api.Client" Version="3.9.9" />
     <PackageReference Include="HtmlSanitizer" Version="9.1.887-beta" />
     <PackageReference Include="Crucible.Common.ServiceDefaults" Version="0.0.2"/>
     <PackageReference Include="TinCan" Version="1.3.0" />

--- a/Blueprint.Api/Blueprint.Api.csproj
+++ b/Blueprint.Api/Blueprint.Api.csproj
@@ -46,7 +46,6 @@
     <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="10.105.0" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageReference Include="Player.Api.Client" Version="3.2.0" />
-    <PackageReference Include="Steamfitter.Api.Client" Version="3.9.9" />
     <PackageReference Include="HtmlSanitizer" Version="9.1.887-beta" />
     <PackageReference Include="Crucible.Common.ServiceDefaults" Version="0.0.2"/>
     <PackageReference Include="TinCan" Version="1.3.0" />
@@ -54,6 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Blueprint.Api.Data\Blueprint.Api.Data.csproj" />
+    <ProjectReference Include="..\..\..\steamfitter\steamfitter.api\Steamfitter.Api.Client\Steamfitter.Api.Client.csproj" />
     <ProjectReference Include="..\Blueprint.Api.Migrations.PostgreSQL\Blueprint.Api.Migrations.PostgreSQL.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/Blueprint.Api/Blueprint.Api.csproj
+++ b/Blueprint.Api/Blueprint.Api.csproj
@@ -46,6 +46,7 @@
     <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="10.105.0" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageReference Include="Player.Api.Client" Version="3.2.0" />
+    <PackageReference Include="steamfitter.api.client" Version="3.9.9" />
     <PackageReference Include="HtmlSanitizer" Version="9.1.887-beta" />
     <PackageReference Include="Crucible.Common.ServiceDefaults" Version="0.0.2"/>
     <PackageReference Include="TinCan" Version="1.3.0" />

--- a/Blueprint.Api/Controllers/MselController.cs
+++ b/Blueprint.Api/Controllers/MselController.cs
@@ -418,6 +418,26 @@ namespace Blueprint.Api.Controllers
         }
 
         /// <summary>
+        /// Cancel pushing integrations and remove any partial integrations
+        /// </summary>
+        /// <remarks>
+        /// Cancels an in-progress integration push and removes any partially created integrations
+        /// <para />
+        /// Accessible only to a ContentDeveloper or MSEL owner
+        /// </remarks>
+        /// <param name="id">The id of the MSEL</param>
+        /// <param name="ct"></param>
+        [HttpPost("msels/{id}/integrations/cancel")]
+        [ProducesResponseType((int)HttpStatusCode.OK)]
+        [SwaggerOperation(OperationId = "cancelIntegrations")]
+        public async Task<IActionResult> CancelIntegrations(Guid id, CancellationToken ct)
+        {
+            var hasSystemPermission = await _authorizationService.AuthorizeAsync([SystemPermission.ManageMsels], ct);
+            await _mselService.CancelIntegrationsAsync(id, hasSystemPermission, ct);
+            return Ok();
+        }
+
+        /// <summary>
         /// End the MSEL deployment and archive it
         /// </summary>
         /// <remarks>

--- a/Blueprint.Api/Hubs/MainHub.cs
+++ b/Blueprint.Api/Hubs/MainHub.cs
@@ -221,7 +221,7 @@ namespace Blueprint.Api.Hubs
         public const string MselCreated = "MselCreated";
         public const string MselUpdated = "MselUpdated";
         public const string MselDeleted = "MselDeleted";
-        public const string MselPushStatusChange = "MselPushStatusChange";
+
         public const string MoveCreated = "MoveCreated";
         public const string MoveUpdated = "MoveUpdated";
         public const string MoveDeleted = "MoveDeleted";

--- a/Blueprint.Api/Hubs/MainHub.cs
+++ b/Blueprint.Api/Hubs/MainHub.cs
@@ -221,6 +221,7 @@ namespace Blueprint.Api.Hubs
         public const string MselCreated = "MselCreated";
         public const string MselUpdated = "MselUpdated";
         public const string MselDeleted = "MselDeleted";
+        public const string IntegrationStatusUpdated = "IntegrationStatusUpdated";
 
         public const string MoveCreated = "MoveCreated";
         public const string MoveUpdated = "MoveUpdated";

--- a/Blueprint.Api/Infrastructure/Extensions/IntegrationCiteExtensions.cs
+++ b/Blueprint.Api/Infrastructure/Extensions/IntegrationCiteExtensions.cs
@@ -42,6 +42,7 @@ namespace Blueprint.Api.Infrastructure.Extensions
         {
             var move0 = msel.Moves.SingleOrDefault(m => m.MoveNumber == 0);
             Evaluation newEvaluation = new Evaluation() {
+                Id = (Guid)msel.CiteEvaluationId,
                 Description = msel.Name,
                 Status = Cite.Api.Client.ItemStatus.Pending,
                 CurrentMoveNumber = 0,
@@ -55,9 +56,6 @@ namespace Blueprint.Api.Infrastructure.Extensions
                 newEvaluation.SituationTime = (DateTimeOffset)move0.SituationTime;
             }
             newEvaluation = await citeApiClient.CreateEvaluationAsync(newEvaluation, ct);
-            // update the MSEL
-            msel.CiteEvaluationId = newEvaluation.Id;
-            await blueprintContext.SaveChangesAsync(ct);
             // delete the default move 0 that was created when the evaluation was created
             var defaultMoveId = newEvaluation.Moves.Single().Id;
             await citeApiClient.DeleteMoveAsync(defaultMoveId, ct);
@@ -107,7 +105,7 @@ namespace Blueprint.Api.Infrastructure.Extensions
             {
                 if (team.CiteTeamTypeId != null)
                 {
-                    var citeTeamId = Guid.NewGuid();
+                    var citeTeamId = team.Id;
                     // create team in Cite
                     var citeTeam = new Team() {
                         Id = citeTeamId,

--- a/Blueprint.Api/Infrastructure/Extensions/IntegrationCiteExtensions.cs
+++ b/Blueprint.Api/Infrastructure/Extensions/IntegrationCiteExtensions.cs
@@ -115,7 +115,6 @@ namespace Blueprint.Api.Infrastructure.Extensions
                         TeamTypeId = (Guid)team.CiteTeamTypeId
                     };
                     citeTeam = await citeApiClient.CreateTeamAsync(citeTeam, ct);
-                    team.CiteTeamId = citeTeam.Id;
                     // use eager-loaded users from the team
                     var users = team.TeamUsers.Select(tu => tu.User).ToList();
                     foreach (var user in users)
@@ -152,13 +151,7 @@ namespace Blueprint.Api.Infrastructure.Extensions
                         {}
                     }
                 }
-                else
-                {
-                    team.CiteTeamId = null;
-                }
             }
-            // save team CiteTeamIds
-            await blueprintContext.SaveChangesAsync(ct);
         }
 
         // Create Cite Duties for this MSEL
@@ -166,7 +159,7 @@ namespace Blueprint.Api.Infrastructure.Extensions
         {
             // Build work items without starting execution
             var duties = msel.CiteDuties
-                .Where(duty => msel.Teams.Any(t => t.Id == duty.TeamId && t.CiteTeamId != null))
+                .Where(duty => msel.Teams.Any(t => t.Id == duty.TeamId && t.CiteTeamTypeId != null))
                 .ToList();
 
             // Process in parallel batches to avoid overwhelming CITE API
@@ -174,11 +167,10 @@ namespace Blueprint.Api.Infrastructure.Extensions
             {
                 var batch = duties.Skip(i).Take(batchSize);
                 await Task.WhenAll(batch.Select(duty => {
-                    var citeTeamId = msel.Teams.SingleOrDefault(t => t.Id == duty.TeamId)?.CiteTeamId;
                     var citeDuty = new Duty() {
                         EvaluationId = (Guid)msel.CiteEvaluationId,
                         Name = duty.Name,
-                        TeamId = (Guid)citeTeamId
+                        TeamId = (Guid)duty.TeamId
                     };
                     return citeApiClient.CreateDutyAsync(citeDuty, ct);
                 }));
@@ -190,7 +182,7 @@ namespace Blueprint.Api.Infrastructure.Extensions
         {
             // Build work items without starting execution
             var actions = msel.CiteActions
-                .Where(action => action.TeamId != null && msel.Teams.Any(t => t.Id == action.TeamId && t.CiteTeamId != null))
+                .Where(action => action.TeamId != null && msel.Teams.Any(t => t.Id == action.TeamId && t.CiteTeamTypeId != null))
                 .ToList();
 
             // Process in parallel batches to avoid overwhelming CITE API
@@ -198,10 +190,9 @@ namespace Blueprint.Api.Infrastructure.Extensions
             {
                 var batch = actions.Skip(i).Take(batchSize);
                 await Task.WhenAll(batch.Select(action => {
-                    var citeTeamId = msel.Teams.SingleOrDefault(t => t.Id == action.TeamId)?.CiteTeamId;
                     var citeAction = new Cite.Api.Client.Action() {
                         EvaluationId = (Guid)msel.CiteEvaluationId,
-                        TeamId = (Guid)citeTeamId,
+                        TeamId = (Guid)action.TeamId,
                         MoveNumber = action.MoveNumber,
                         InjectNumber = action.InjectNumber,
                         Description = action.Description

--- a/Blueprint.Api/Infrastructure/Extensions/IntegrationGalleryExtensions.cs
+++ b/Blueprint.Api/Infrastructure/Extensions/IntegrationGalleryExtensions.cs
@@ -42,28 +42,24 @@ namespace Blueprint.Api.Infrastructure.Extensions
         public static async Task CreateCollectionAsync(MselEntity msel, GalleryApiClient galleryApiClient, BlueprintContext blueprintContext, CancellationToken ct)
         {
             Collection newCollection = new Collection() {
+                Id = (Guid)msel.GalleryCollectionId,
                 Name = msel.Name,
                 Description = msel.Description
             };
-            newCollection = await galleryApiClient.CreateCollectionAsync(newCollection, ct);
-            // update the MSEL
-            msel.GalleryCollectionId = newCollection.Id;
-            await blueprintContext.SaveChangesAsync(ct);
+            await galleryApiClient.CreateCollectionAsync(newCollection, ct);
         }
 
         // Create a Gallery Exhibit for this MSEL
         public static async Task CreateExhibitAsync(MselEntity msel, GalleryApiClient galleryApiClient, BlueprintContext blueprintContext, CancellationToken ct)
         {
             Exhibit newExhibit = new Exhibit() {
+                Id = (Guid)msel.GalleryExhibitId,
                 CollectionId = (Guid)msel.GalleryCollectionId,
                 ScenarioId = msel.SteamfitterScenarioId,
                 CurrentMove = 0,
                 CurrentInject = 0
             };
-            newExhibit = await galleryApiClient.CreateExhibitAsync(newExhibit, ct);
-            // update the MSEL
-            msel.GalleryExhibitId = newExhibit.Id;
-            await blueprintContext.SaveChangesAsync(ct);
+            await galleryApiClient.CreateExhibitAsync(newExhibit, ct);
         }
 
         // Create Gallery Teams for this MSEL
@@ -73,7 +69,7 @@ namespace Blueprint.Api.Infrastructure.Extensions
             var teams = msel.Teams.ToList();
             foreach (var team in teams)
             {
-                var galleryTeamId = Guid.NewGuid();
+                var galleryTeamId = team.Id;
                 // create team in Gallery
                 var galleryTeam = new Team() {
                     Id = galleryTeamId,

--- a/Blueprint.Api/Infrastructure/Extensions/IntegrationGalleryExtensions.cs
+++ b/Blueprint.Api/Infrastructure/Extensions/IntegrationGalleryExtensions.cs
@@ -79,7 +79,6 @@ namespace Blueprint.Api.Infrastructure.Extensions
                     Email = team.Email
                 };
                 galleryTeam = await galleryApiClient.CreateTeamAsync(galleryTeam, ct);
-                team.GalleryTeamId = galleryTeam.Id;
                 // use eager-loaded users from the team
                 var users = team.TeamUsers.Select(tu => tu.User).ToList();
                 foreach (var user in users)
@@ -141,7 +140,7 @@ namespace Blueprint.Api.Infrastructure.Extensions
                     var cardTeams = allCardTeams.Where(cdt => cdt.CardId == card.Id).ToList();
                     var teamCardTasks = cardTeams.Select(cardTeam => {
                         var newTeamCard = new TeamCard() {
-                            TeamId = (Guid)cardTeam.Team.GalleryTeamId,
+                            TeamId = cardTeam.Team.Id,
                             CardId = (Guid)card.GalleryId,
                             IsShownOnWall = cardTeam.IsShownOnWall,
                             CanPostArticles = cardTeam.CanPostArticles
@@ -226,7 +225,7 @@ namespace Blueprint.Api.Infrastructure.Extensions
                     {
                         var newArticleTeam = new TeamArticle() {
                             ExhibitId = (Guid)msel.GalleryExhibitId,
-                            TeamId = (Guid)team.GalleryTeamId,
+                            TeamId = team.Id,
                             ArticleId = galleryArticle.Id
                         };
                         await galleryApiClient.CreateTeamArticleAsync(newArticleTeam, ct);

--- a/Blueprint.Api/Infrastructure/Extensions/IntegrationPlayerExtensions.cs
+++ b/Blueprint.Api/Infrastructure/Extensions/IntegrationPlayerExtensions.cs
@@ -40,16 +40,14 @@ namespace Blueprint.Api.Infrastructure.Extensions
         public static async Task CreateViewAsync(MselEntity msel, Guid? playerViewId, PlayerApiClient playerApiClient, BlueprintContext blueprintContext, CancellationToken ct)
         {
             ViewForm viewForm = new ViewForm() {
+                Id = (Guid)msel.PlayerViewId,
                 Name = msel.Name,
                 Description = msel.Description,
                 Status = ViewStatus.Active,
                 CreateAdminTeam = true
             };
             if (playerViewId != null) viewForm.Id = (Guid)playerViewId;
-            var newView = await playerApiClient.CreateViewAsync(viewForm, ct);
-            // update the MSEL
-            msel.PlayerViewId = newView.Id;
-            await blueprintContext.SaveChangesAsync(ct);
+            await playerApiClient.CreateViewAsync(viewForm, ct);
         }
 
         // Create Player Teams for this MSEL
@@ -59,12 +57,12 @@ namespace Blueprint.Api.Infrastructure.Extensions
             var teams = msel.Teams.ToList();
             foreach (var team in teams)
             {
-                // create team in Player
+                // create team in Player using the Blueprint team ID
                 var playerTeamForm = new TeamForm() {
+                    Id = team.Id,
                     Name = team.Name
                 };
-                var playerTeam = await playerApiClient.CreateTeamAsync((Guid)msel.PlayerViewId, playerTeamForm, ct);
-                team.PlayerTeamId = playerTeam.Id;
+                await playerApiClient.CreateTeamAsync((Guid)msel.PlayerViewId, playerTeamForm, ct);
                 // use eager-loaded users from the team
                 var users = team.TeamUsers.Select(tu => tu.User).ToList();
 
@@ -81,11 +79,10 @@ namespace Blueprint.Api.Infrastructure.Extensions
                         playerUserIds.Add(user.Id);
                     }
                     // create Player TeamUsers
-                    await playerApiClient.AddUserToTeamAsync(playerTeam.Id, user.Id, ct);
+                    await playerApiClient.AddUserToTeamAsync(team.Id, user.Id, ct);
                 });
                 await Task.WhenAll(userTasks);
             }
-            // save the teams PlayerTeamId values
             await blueprintContext.SaveChangesAsync(ct);
         }
 

--- a/Blueprint.Api/Infrastructure/Extensions/IntegrationPlayerExtensions.cs
+++ b/Blueprint.Api/Infrastructure/Extensions/IntegrationPlayerExtensions.cs
@@ -83,7 +83,6 @@ namespace Blueprint.Api.Infrastructure.Extensions
                 });
                 await Task.WhenAll(userTasks);
             }
-            await blueprintContext.SaveChangesAsync(ct);
         }
 
         // Create Player Applications for this MSEL
@@ -143,7 +142,7 @@ namespace Blueprint.Api.Infrastructure.Extensions
                 foreach (var applicationTeam in applicationTeams)
                 {
                     var applicationInstanceForm = new ApplicationInstanceForm() {
-                        TeamId = (Guid)applicationTeam.Team.PlayerTeamId,
+                        TeamId = applicationTeam.Team.Id,
                         ApplicationId = (Guid)playerApplication.Id,
                         DisplayOrder = applicationTeam.DisplayOrder
                     };

--- a/Blueprint.Api/Infrastructure/Extensions/IntegrationSteamfitterExtensions.cs
+++ b/Blueprint.Api/Infrastructure/Extensions/IntegrationSteamfitterExtensions.cs
@@ -54,6 +54,7 @@ namespace Blueprint.Api.Infrastructure.Extensions
             startDate = msel.StartTime < startDate ? startDate : msel.StartTime;
             ScenarioForm scenarioForm = new ScenarioForm()
             {
+                Id = msel.SteamfitterScenarioId,
                 Name = msel.Name,
                 Description = msel.Description,
                 Status = ScenarioStatus.Active,
@@ -63,9 +64,6 @@ namespace Blueprint.Api.Infrastructure.Extensions
                 View = msel.Name
             };
             var newScenario = await steamfitterApiClient.CreateScenarioAsync(scenarioForm, ct);
-            // update the MSEL
-            msel.SteamfitterScenarioId = newScenario.Id;
-            await blueprintContext.SaveChangesAsync(ct);
 
             return newScenario;
         }

--- a/Blueprint.Api/Services/AddApplicationQueue.cs
+++ b/Blueprint.Api/Services/AddApplicationQueue.cs
@@ -34,7 +34,7 @@ namespace Blueprint.Api.Services
     public class AddApplicationInformation
     {
         public Application Application { get; set; }
-        public Guid PlayerTeamId { get; set; }
+        public Guid TeamId { get; set; }
         public int DisplayOrder { get; set; }
 
     }

--- a/Blueprint.Api/Services/AddApplicationService.cs
+++ b/Blueprint.Api/Services/AddApplicationService.cs
@@ -102,7 +102,7 @@ namespace Blueprint.Api.Services
                     var playerApplication = await playerApiClient.CreateApplicationAsync(addApplicationInformation.Application.ViewId, addApplicationInformation.Application, ct);
                     // create the Player Team Application
                     var applicationInstanceForm = new ApplicationInstanceForm() {
-                        TeamId = addApplicationInformation.PlayerTeamId,
+                        TeamId = addApplicationInformation.TeamId,
                         ApplicationId = playerApplication.Id,
                         DisplayOrder = addApplicationInformation.DisplayOrder
                     };

--- a/Blueprint.Api/Services/IntegrationService.cs
+++ b/Blueprint.Api/Services/IntegrationService.cs
@@ -1,15 +1,14 @@
 // Copyright 2024 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Blueprint.Api.Data.Models;
-using Blueprint.Api.Hubs;
 using System;
+using System.Collections.Concurrent;
 using System.Net.Http;
 using System.Threading;
 using STT = System.Threading.Tasks;
@@ -27,6 +26,7 @@ namespace Blueprint.Api.Services
 {
     public interface IIntegrationService : IHostedService
     {
+        void CancelPush(Guid mselId);
     }
 
     public class IntegrationService : IIntegrationService
@@ -34,22 +34,20 @@ namespace Blueprint.Api.Services
         private readonly ILogger<IntegrationService> _logger;
         private readonly IServiceScopeFactory _scopeFactory;
         private readonly IIntegrationQueue _integrationQueue;
-        private readonly IHubContext<MainHub> _hubContext;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly IOptionsMonitor<Infrastructure.Options.ClientOptions> _clientOptions;
+        private readonly ConcurrentDictionary<Guid, CancellationTokenSource> _cancellationTokenSources = new();
 
         public IntegrationService(
             ILogger<IntegrationService> logger,
             IServiceScopeFactory scopeFactory,
             IIntegrationQueue integrationQueue,
-            IHubContext<MainHub> mainHub,
             IHttpClientFactory httpClientFactory,
             IOptionsMonitor<Infrastructure.Options.ClientOptions> clientOptions)
         {
             _logger = logger;
             _scopeFactory = scopeFactory;
             _integrationQueue = integrationQueue;
-            _hubContext = mainHub;
             _httpClientFactory = httpClientFactory;
             _clientOptions = clientOptions;
         }
@@ -64,6 +62,65 @@ namespace Blueprint.Api.Services
         public STT.Task StopAsync(CancellationToken cancellationToken)
         {
             return STT.Task.CompletedTask;
+        }
+
+        public void CancelPush(Guid mselId)
+        {
+            if (_cancellationTokenSources.TryGetValue(mselId, out var cts))
+                cts.Cancel();
+            else
+                _ = PerformCancelCleanupAsync(mselId);
+        }
+
+        private async STT.Task PerformCancelCleanupAsync(Guid mselId)
+        {
+            _logger.LogInformation($"Integration push cancelled for MSEL {mselId}. Starting cleanup.");
+            var freshCt = new CancellationToken();
+            try
+            {
+                // Use a fresh scope and context - the original may be in a bad state after cancellation.
+                using var cleanupScope = _scopeFactory.CreateScope();
+                using var cleanupContext = cleanupScope.ServiceProvider.GetRequiredService<BlueprintContext>();
+                var freshMsel = await cleanupContext.Msels
+                    .Include(m => m.PlayerApplications).ThenInclude(pa => pa.PlayerApplicationTeams)
+                    .Include(m => m.Cards)
+                    .Include(m => m.DataFields)
+                    .Include(m => m.ScenarioEvents).ThenInclude(se => se.DataValues)
+                    .Include(m => m.ScenarioEvents).ThenInclude(se => se.SteamfitterTask)
+                    .Include(m => m.Moves)
+                    .Include(m => m.CiteActions)
+                    .Include(m => m.CiteDuties)
+                    .Include(m => m.Teams).ThenInclude(t => t.TeamUsers).ThenInclude(tu => tu.User)
+                    .Include(m => m.Teams).ThenInclude(t => t.UserTeamRoles)
+                    .AsSplitQuery()
+                    .FirstOrDefaultAsync(m => m.Id == mselId, freshCt);
+                if (freshMsel != null)
+                {
+                    freshMsel.Status = Data.Enumerations.MselItemStatus.Pulling;
+                    await UpdateIntegrationStatusAsync(freshMsel, cleanupContext, "Cancelling - removing partial integrations", freshCt);
+                    var tokenResponse = await ApiClientsExtensions.GetToken(cleanupScope);
+                    var pullInfo = new IntegrationInformation
+                    {
+                        MselId = mselId,
+                        IsPush = false,
+                        FinalStatus = Data.Enumerations.MselItemStatus.Approved
+                    };
+                    await PullIntegrations(freshMsel, pullInfo, cleanupContext, tokenResponse, freshCt);
+                }
+            }
+            catch (System.Exception cleanupEx)
+            {
+                _logger.LogError(cleanupEx, $"Error during cancellation cleanup for MSEL {mselId}");
+                try
+                {
+                    using var errorScope = _scopeFactory.CreateScope();
+                    using var errorContext = errorScope.ServiceProvider.GetRequiredService<BlueprintContext>();
+                    var errorMsel = await errorContext.Msels.FindAsync(mselId);
+                    if (errorMsel != null)
+                        await UpdateIntegrationStatusAsync(errorMsel, errorContext, $"ERROR: Cancellation cleanup failed - {cleanupEx.Message}", freshCt);
+                }
+                catch { /* best effort */ }
+            }
         }
 
         private async STT.Task Run()
@@ -90,10 +147,18 @@ namespace Blueprint.Api.Services
             });
         }
 
+        private async STT.Task UpdateIntegrationStatusAsync(MselEntity msel, BlueprintContext blueprintContext, string status, CancellationToken ct)
+        {
+            msel.IntegrationStatus = status;
+            await blueprintContext.SaveChangesAsync(ct);
+        }
+
         private async void ProcessTheMsel(Object integrationInformationObject)
         {
-            var ct = new CancellationToken();
             var integrationInformation = (IntegrationInformation)integrationInformationObject;
+            var cts = new CancellationTokenSource();
+            _cancellationTokenSources[integrationInformation.MselId] = cts;
+            var ct = cts.Token;
             var currentProcessStep = "Begin processing";
             _logger.LogDebug($"{currentProcessStep} {integrationInformation.MselId}");
             try
@@ -119,18 +184,40 @@ namespace Blueprint.Api.Services
                         .Include(m => m.Teams).ThenInclude(t => t.UserTeamRoles)
                         .AsSplitQuery()
                         .SingleOrDefaultAsync(m => m.Id == integrationInformation.MselId);
-                    var isAPush = !(
-                        msel.PlayerViewId != null ||
-                        msel.GalleryExhibitId != null ||
-                        msel.CiteEvaluationId != null ||
-                        msel.SteamfitterScenarioId != null);
-                    var hubGroup = _hubContext.Clients.Group(msel.Id.ToString());
+                    var isAPush = integrationInformation.IsPush;
                     currentProcessStep = "Try processing the MSEL";
                     try
                     {
                         PlayerApiClient playerApiClient = null;
                         currentProcessStep = "Getting Auth Token with scope " + scope;
                         var tokenResponse = await ApiClientsExtensions.GetToken(scope);
+                        if (isAPush)
+                        {
+                            // Pre-generate integration object IDs and save before calling remote APIs
+                            if (msel.UsePlayer && msel.PlayerViewId == null)
+                                msel.PlayerViewId = Guid.NewGuid();
+                            if (msel.UseGallery)
+                            {
+                                if (msel.GalleryCollectionId == null)
+                                    msel.GalleryCollectionId = Guid.NewGuid();
+                                if (msel.GalleryExhibitId == null)
+                                    msel.GalleryExhibitId = Guid.NewGuid();
+                            }
+                            if (msel.UseCite && msel.CiteEvaluationId == null)
+                                msel.CiteEvaluationId = Guid.NewGuid();
+                            if (msel.UseSteamfitter && msel.SteamfitterScenarioId == null)
+                                msel.SteamfitterScenarioId = Guid.NewGuid();
+
+                            // Pre-set team IDs to match Blueprint team IDs
+                            foreach (var team in msel.Teams)
+                            {
+                                if (msel.UsePlayer) team.PlayerTeamId = team.Id;
+                                if (msel.UseGallery) team.GalleryTeamId = team.Id;
+                                if (msel.UseCite && team.CiteTeamTypeId != null) team.CiteTeamId = team.Id;
+                            }
+
+                            await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Integrations", ct);
+                        }
                         if (isAPush)
                         {
                             // Create all API clients upfront
@@ -169,8 +256,7 @@ namespace Blueprint.Api.Services
                             // Player processing part 1
                             if (msel.UsePlayer)
                             {
-                                currentProcessStep = "Player - get API client with token: " + tokenResponse.AccessToken;
-                                await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Pushing Integrations", null, ct);
+                                ct.ThrowIfCancellationRequested();
                                 currentProcessStep = "Player - begin processing part 1";
                                 await PlayerProcessPart1(msel, integrationInformation.PlayerViewId, playerApiClient, blueprintContext, playerUserIds, ct);
                             }
@@ -178,6 +264,7 @@ namespace Blueprint.Api.Services
                             // Gallery processing
                             if (msel.UseGallery)
                             {
+                                ct.ThrowIfCancellationRequested();
                                 currentProcessStep = "Gallery - get scenario event service";
                                 var scenarioEventService = scope.ServiceProvider.GetRequiredService<IScenarioEventService>();
                                 currentProcessStep = "Gallery - start GalleryProcess";
@@ -187,6 +274,7 @@ namespace Blueprint.Api.Services
                             // CITE processing
                             if (msel.UseCite)
                             {
+                                ct.ThrowIfCancellationRequested();
                                 currentProcessStep = "CITE - begin processing";
                                 await CiteProcess(msel, citeApiClient, blueprintContext, citeUserIds, ct);
                             }
@@ -194,6 +282,7 @@ namespace Blueprint.Api.Services
                             // Steamfitter processing
                             if (msel.UseSteamfitter)
                             {
+                                ct.ThrowIfCancellationRequested();
                                 currentProcessStep = "Steamfitter - begin processing";
                                 await SteamfitterProcess(msel, steamfitterApiClient, blueprintContext, ct);
                             }
@@ -201,122 +290,42 @@ namespace Blueprint.Api.Services
                             // Player processing part 2
                             if (msel.UsePlayer)
                             {
-                                await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Push Player Applications", null, ct);
+                                ct.ThrowIfCancellationRequested();
+                                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Player Applications", ct);
                                 currentProcessStep = "Player - push applications";
                                 await IntegrationPlayerExtensions.CreateApplicationsAsync(msel, playerApiClient, blueprintContext, _clientOptions.CurrentValue.PlayerMaxConcurrentRequests, _clientOptions.CurrentValue, ct);
                             }
                             // set the MSEL status
+                            msel.IntegrationStatus = null;
                             msel.Status = Data.Enumerations.MselItemStatus.Deployed;
                             await blueprintContext.SaveChangesAsync(ct);
 
                             // Clear tracked entities to prevent accumulation across operations
                             blueprintContext.ChangeTracker.Clear();
-
-                            // tell UI we are done
-                            await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + "", null, ct);
                         }
                         else
                         {
-                            await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Pulling Integrations", null, ct);
-                            // Pull from Steamfitter
-                            if (msel.SteamfitterScenarioId != null)
-                            {
-                                try
-                                {
-                                    currentProcessStep = "Steamfitter - pull scenario";
-                                    await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Pulling Steamfitter Scenario", null, ct);
-                                    var steamfitterApiClient = IntegrationSteamfitterExtensions.GetSteamfitterApiClient(_httpClientFactory, _clientOptions.CurrentValue.SteamfitterApiUrl, tokenResponse);
-                                    await IntegrationSteamfitterExtensions.PullFromSteamfitterAsync((Guid)msel.SteamfitterScenarioId, steamfitterApiClient, ct);
-                                }
-                                catch (System.Exception ex)
-                                {
-                                    _logger.LogError(ex, $"{currentProcessStep} ({msel.Id})");
-                                    await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, $"{msel.Id},ERROR: {currentProcessStep} failed - {ex.Message}", null, ct);
-                                }
-                            }
-                            // Pull from CITE
-                            if (msel.CiteEvaluationId != null)
-                            {
-                                try
-                                {
-                                    // Get CITE API client
-                                    currentProcessStep = "CITE - get API client";
-                                    var citeApiClient = IntegrationCiteExtensions.GetCiteApiClient(_httpClientFactory, _clientOptions.CurrentValue.CiteApiUrl, tokenResponse);
-
-                                    currentProcessStep = "CITE - pull evaluation";
-                                    await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Pulling CITE Evaluation", null, ct);
-                                    await IntegrationCiteExtensions.PullFromCiteAsync((Guid)msel.CiteEvaluationId, citeApiClient, ct);
-                                }
-                                catch (System.Exception ex)
-                                {
-                                    _logger.LogError(ex, $"{currentProcessStep} ({msel.Id})");
-                                    await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, $"{msel.Id},ERROR: {currentProcessStep} failed - {ex.Message}", null, ct);
-                                }
-                            }
-                            // Pull from Gallery
-                            if (msel.GalleryCollectionId != null)
-                            {
-                                try
-                                {
-                                    // Get Gallery API client
-                                    currentProcessStep = "Gallery - get API client";
-                                    var galleryApiClient = IntegrationGalleryExtensions.GetGalleryApiClient(_httpClientFactory, _clientOptions.CurrentValue.GalleryApiUrl, tokenResponse);
-                                    currentProcessStep = "Gallery - pull collection";
-                                    await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Pulling Gallery Collection", null, ct);
-                                    await IntegrationGalleryExtensions.PullFromGalleryAsync((Guid)msel.GalleryCollectionId, galleryApiClient, ct);
-                                }
-                                catch (System.Exception ex)
-                                {
-                                    _logger.LogError(ex, $"{currentProcessStep} ({msel.Id})");
-                                    await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, $"{msel.Id},ERROR: {currentProcessStep} failed - {ex.Message}", null, ct);
-                                }
-                            }
-                            // Pull from Player
-                            if (msel.PlayerViewId != null)
-                            {
-                                try
-                                {
-                                    currentProcessStep = "Player - get API client with token: " + tokenResponse.AccessToken;
-                                    playerApiClient = IntegrationPlayerExtensions.GetPlayerApiClient(_httpClientFactory, _clientOptions.CurrentValue.PlayerApiUrl, tokenResponse);
-                                    currentProcessStep = "Player - pull view";
-                                    await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Pulling Player View", null, ct);
-                                    // TODO:  Player requires two deletes?
-                                    await IntegrationPlayerExtensions.PullFromPlayerAsync((Guid)msel.PlayerViewId, playerApiClient, ct);
-                                    await IntegrationPlayerExtensions.PullFromPlayerAsync((Guid)msel.PlayerViewId, playerApiClient, ct);
-                                }
-                                catch (System.Exception ex)
-                                {
-                                    _logger.LogError(ex, $"{currentProcessStep} ({msel.Id})");
-                                    await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, $"{msel.Id},ERROR: {currentProcessStep} failed - {ex.Message}", null, ct);
-                                }
-                            }
-                            // update the MSEL
-                            currentProcessStep = "MSEL update ";
-                            var mselId = msel.Id;
-                            msel = await blueprintContext.Msels.FirstOrDefaultAsync(m => m.Id == mselId);
-                            if (msel != null)
-                            {
-                                msel.CiteEvaluationId = null;
-                                msel.GalleryExhibitId = null;
-                                msel.GalleryCollectionId = null;
-                                msel.PlayerViewId = null;
-                                msel.SteamfitterScenarioId = null;
-                                msel.Status = integrationInformation.FinalStatus;
-                                await blueprintContext.SaveChangesAsync(ct);
-                            }
-
-                            // Clear tracked entities to prevent accumulation across operations
-                            blueprintContext.ChangeTracker.Clear();
-
-                            // send completion status
-                            await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, mselId + "", null, ct);
+                            await PullIntegrations(msel, integrationInformation, blueprintContext, tokenResponse, ct);
                         }
 
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // Rollback any open transaction to release DB row locks before cleanup.
+                        // GalleryProcess opens a transaction on blueprintContext; if cancelled mid-flight,
+                        // that transaction holds a lock on the msels row that PerformCancelCleanupAsync needs.
+                        if (blueprintContext.Database.CurrentTransaction != null)
+                        {
+                            try { await blueprintContext.Database.RollbackTransactionAsync(); }
+                            catch { /* best effort */ }
+                        }
+                        await PerformCancelCleanupAsync(msel.Id);
                     }
                     catch (System.Exception ex)
                     {
                         _logger.LogError(ex, $"{currentProcessStep} ({msel.Id})");
-                        await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, $"{msel.Id},ERROR: {currentProcessStep} failed - {ex.Message}", null, ct);
+                        var freshCt = new CancellationToken();
+                        await UpdateIntegrationStatusAsync(msel, blueprintContext, $"ERROR: {currentProcessStep} failed - {ex.Message}", freshCt);
                     }
 
                 }
@@ -324,13 +333,128 @@ namespace Blueprint.Api.Services
             catch (System.Exception ex)
             {
                 _logger.LogError(ex, $"{currentProcessStep} {integrationInformation}");
-                var mselId = integrationInformation?.MselId ?? Guid.Empty;
-                if (mselId != Guid.Empty)
+                // Try to update integration status with error in a fresh context
+                try
                 {
-                    var errorHubGroup = _hubContext.Clients.Group(mselId.ToString());
-                    await errorHubGroup.SendAsync(MainHubMethods.MselPushStatusChange, $"{mselId},ERROR: {currentProcessStep} failed - {ex.Message}", null, ct);
+                    using var scope = _scopeFactory.CreateScope();
+                    using var blueprintContext = scope.ServiceProvider.GetRequiredService<BlueprintContext>();
+                    var mselId = integrationInformation?.MselId ?? Guid.Empty;
+                    if (mselId != Guid.Empty)
+                    {
+                        var msel = await blueprintContext.Msels.FindAsync(mselId);
+                        if (msel != null)
+                        {
+                            msel.IntegrationStatus = $"ERROR: {currentProcessStep} failed - {ex.Message}";
+                            await blueprintContext.SaveChangesAsync();
+                        }
+                    }
+                }
+                catch (System.Exception innerEx)
+                {
+                    _logger.LogError(innerEx, "Failed to update integration status after outer error.");
                 }
             }
+            finally
+            {
+                _cancellationTokenSources.TryRemove(integrationInformation.MselId, out _);
+                cts.Dispose();
+            }
+        }
+
+        private async STT.Task PullIntegrations(MselEntity msel, IntegrationInformation integrationInformation, BlueprintContext blueprintContext, IdentityModel.Client.TokenResponse tokenResponse, CancellationToken ct)
+        {
+            var currentProcessStep = "Pulling Integrations";
+            await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pulling Integrations", ct);
+            PlayerApiClient playerApiClient = null;
+
+            // Pull from Steamfitter
+            if (msel.SteamfitterScenarioId != null)
+            {
+                try
+                {
+                    currentProcessStep = "Steamfitter - pull scenario";
+                    await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pulling Steamfitter Scenario", ct);
+                    var steamfitterApiClient = IntegrationSteamfitterExtensions.GetSteamfitterApiClient(_httpClientFactory, _clientOptions.CurrentValue.SteamfitterApiUrl, tokenResponse);
+                    await IntegrationSteamfitterExtensions.PullFromSteamfitterAsync((Guid)msel.SteamfitterScenarioId, steamfitterApiClient, ct);
+                }
+                catch (System.Exception ex)
+                {
+                    _logger.LogError(ex, $"{currentProcessStep} ({msel.Id})");
+                }
+            }
+            // Pull from CITE
+            if (msel.CiteEvaluationId != null)
+            {
+                try
+                {
+                    currentProcessStep = "CITE - pull evaluation";
+                    await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pulling CITE Evaluation", ct);
+                    var citeApiClient = IntegrationCiteExtensions.GetCiteApiClient(_httpClientFactory, _clientOptions.CurrentValue.CiteApiUrl, tokenResponse);
+                    await IntegrationCiteExtensions.PullFromCiteAsync((Guid)msel.CiteEvaluationId, citeApiClient, ct);
+                }
+                catch (System.Exception ex)
+                {
+                    _logger.LogError(ex, $"{currentProcessStep} ({msel.Id})");
+                }
+            }
+            // Pull from Gallery
+            if (msel.GalleryCollectionId != null)
+            {
+                try
+                {
+                    currentProcessStep = "Gallery - pull collection";
+                    await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pulling Gallery Collection", ct);
+                    var galleryApiClient = IntegrationGalleryExtensions.GetGalleryApiClient(_httpClientFactory, _clientOptions.CurrentValue.GalleryApiUrl, tokenResponse);
+                    await IntegrationGalleryExtensions.PullFromGalleryAsync((Guid)msel.GalleryCollectionId, galleryApiClient, ct);
+                }
+                catch (System.Exception ex)
+                {
+                    _logger.LogError(ex, $"{currentProcessStep} ({msel.Id})");
+                }
+            }
+            // Pull from Player
+            if (msel.PlayerViewId != null)
+            {
+                try
+                {
+                    currentProcessStep = "Player - pull view";
+                    await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pulling Player View", ct);
+                    playerApiClient = IntegrationPlayerExtensions.GetPlayerApiClient(_httpClientFactory, _clientOptions.CurrentValue.PlayerApiUrl, tokenResponse);
+                    // TODO:  Player requires two deletes?
+                    await IntegrationPlayerExtensions.PullFromPlayerAsync((Guid)msel.PlayerViewId, playerApiClient, ct);
+                    await IntegrationPlayerExtensions.PullFromPlayerAsync((Guid)msel.PlayerViewId, playerApiClient, ct);
+                }
+                catch (System.Exception ex)
+                {
+                    _logger.LogError(ex, $"{currentProcessStep} ({msel.Id})");
+                }
+            }
+            // update the MSEL
+            currentProcessStep = "MSEL update";
+            var mselId = msel.Id;
+            msel = await blueprintContext.Msels.FirstOrDefaultAsync(m => m.Id == mselId);
+            if (msel != null)
+            {
+                msel.CiteEvaluationId = null;
+                msel.GalleryExhibitId = null;
+                msel.GalleryCollectionId = null;
+                msel.PlayerViewId = null;
+                msel.SteamfitterScenarioId = null;
+                // Clear team integration IDs
+                var teams = await blueprintContext.Teams.Where(t => t.MselId == mselId).ToListAsync(ct);
+                foreach (var team in teams)
+                {
+                    team.PlayerTeamId = null;
+                    team.GalleryTeamId = null;
+                    team.CiteTeamId = null;
+                }
+                msel.IntegrationStatus = null;
+                msel.Status = integrationInformation.FinalStatus;
+                await blueprintContext.SaveChangesAsync(ct);
+            }
+
+            // Clear tracked entities to prevent accumulation across operations
+            blueprintContext.ChangeTracker.Clear();
         }
 
         private bool CanMselBePushed(MselEntity mselToIntegrate)
@@ -342,116 +466,105 @@ namespace Blueprint.Api.Services
         private async STT.Task PlayerProcessPart1(MselEntity msel, Guid? playerViewId, PlayerApiClient playerApiClient, BlueprintContext blueprintContext, HashSet<Guid> playerUserIds, CancellationToken ct)
         {
             var currentProcessStep = "Player create view";
-            var hubGroup = _hubContext.Clients.Group(msel.Id.ToString());
             try
             {
                 // create the Player View
-                await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Pushing View to Player", null, ct);
+                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing View to Player", ct);
                 await IntegrationPlayerExtensions.CreateViewAsync(msel, playerViewId, playerApiClient, blueprintContext, ct);
                 // create the Player Teams
                 currentProcessStep = "Player create teams";
-                await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Pushing Teams to Player", null, ct);
+                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Teams to Player", ct);
                 await IntegrationPlayerExtensions.CreateTeamsAsync(msel, playerApiClient, blueprintContext, playerUserIds, ct);
             }
             catch (System.Exception ex)
             {
                 _logger.LogError(ex, $"{currentProcessStep} ({msel.Id})");
-                await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, $"{msel.Id},ERROR: {currentProcessStep} failed - {ex.Message}", null, ct);
                 throw;
             }
         }
 
         private async STT.Task CiteProcess(MselEntity msel, CiteApiClient citeApiClient, BlueprintContext blueprintContext, HashSet<Guid> citeUserIds, CancellationToken ct)
         {
-            var currentProcessStep = "CITE - get hubGroup";
-            var hubGroup = _hubContext.Clients.Group(msel.Id.ToString());
+            var currentProcessStep = "CITE - create evaluation";
             try
             {
                 // create the Cite Evaluation
-                currentProcessStep = "CITE - create evaluation";
-                await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Pushing Evaluation to CITE", null, ct);
+                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Evaluation to CITE", ct);
                 var evaluation = await IntegrationCiteExtensions.CreateEvaluationAsync(msel, citeApiClient, blueprintContext, ct);
                 // create the Cite Moves
                 currentProcessStep = "CITE - create moves";
-                await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Pushing Moves to CITE", null, ct);
+                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Moves to CITE", ct);
                 await IntegrationCiteExtensions.CreateMovesAsync(msel, citeApiClient, blueprintContext, _clientOptions.CurrentValue.CiteMaxConcurrentRequests, ct);
                 // create the Cite Teams
                 currentProcessStep = "CITE - create teams";
-                await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Pushing Teams to CITE", null, ct);
+                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Teams to CITE", ct);
                 await IntegrationCiteExtensions.CreateTeamsAsync(msel, citeApiClient, blueprintContext, citeUserIds, ct);
                 // create the Cite Duties
                 currentProcessStep = "CITE - create duties";
-                await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Pushing Duties to CITE", null, ct);
+                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Duties to CITE", ct);
                 await IntegrationCiteExtensions.CreateDutiesAsync(msel, citeApiClient, blueprintContext, _clientOptions.CurrentValue.CiteMaxConcurrentRequests, ct);
                 // create the Cite Actions
                 currentProcessStep = "CITE - create actions";
-                await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Pushing Actions to CITE", null, ct);
+                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Actions to CITE", ct);
                 await IntegrationCiteExtensions.CreateActionsAsync(msel, citeApiClient, blueprintContext, _clientOptions.CurrentValue.CiteMaxConcurrentRequests, ct);
                 // update the evaluation, so that submissions get created
                 currentProcessStep = "CITE - advance";
-                await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Finishing Evaluation to CITE", null, ct);
+                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Finishing Evaluation to CITE", ct);
                 evaluation.Status = Cite.Api.Client.ItemStatus.Active;
                 await IntegrationCiteExtensions.ActivateAsync(evaluation, citeApiClient, blueprintContext, ct);
             }
             catch (System.Exception ex)
             {
                 _logger.LogError(ex, $"{currentProcessStep} ({msel.Id})");
-                await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, $"{msel.Id},ERROR: {currentProcessStep} failed - {ex.Message}", null, ct);
                 throw;
             }
         }
 
         private async STT.Task GalleryProcess(MselEntity msel, IScenarioEventService scenarioEventService, GalleryApiClient galleryApiClient, BlueprintContext blueprintContext, HashSet<Guid> galleryUserIds, CancellationToken ct)
         {
-            var currentProcessStep = "Gallery - get hubGroup";
-            var hubGroup = _hubContext.Clients.Group(msel.Id.ToString());
+            var currentProcessStep = "Gallery - begin transaction";
             try
             {
                 // start a transaction, because we will modify many database items
-                currentProcessStep = "Gallery - begin transaction";
                 await blueprintContext.Database.BeginTransactionAsync();
                 // create the Gallery Collection
                 currentProcessStep = "Gallery - Pushing Collection";
-                await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Pushing Collection to Gallery", null, ct);
+                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Collection to Gallery", ct);
                 await IntegrationGalleryExtensions.CreateCollectionAsync(msel, galleryApiClient, blueprintContext, ct);
                 // create the Gallery Exhibit
                 currentProcessStep = "Gallery - Pushing Exhibit";
-                await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Pushing Exhibit to Gallery", null, ct);
+                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Exhibit to Gallery", ct);
                 await IntegrationGalleryExtensions.CreateExhibitAsync(msel, galleryApiClient, blueprintContext, ct);
                 // create the Gallery Teams
                 currentProcessStep = "Gallery - Pushing Teams";
-                await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Pushing Teams to Gallery", null, ct);
+                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Teams to Gallery", ct);
                 await IntegrationGalleryExtensions.CreateTeamsAsync(msel, galleryApiClient, blueprintContext, galleryUserIds, ct);
                 // create the Gallery Cards
                 currentProcessStep = "Gallery - Pushing Cards";
-                await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Pushing Cards to Gallery", null, ct);
+                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Cards to Gallery", ct);
                 await IntegrationGalleryExtensions.CreateCardsAsync(msel, galleryApiClient, blueprintContext, _clientOptions.CurrentValue.GalleryMaxConcurrentRequests, ct);
                 // create the Gallery Articles
                 currentProcessStep = "Gallery - Pushing Articles";
-                await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Pushing Articles to Gallery", null, ct);
+                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Articles to Gallery", ct);
                 await IntegrationGalleryExtensions.CreateArticlesAsync(msel, galleryApiClient, blueprintContext, scenarioEventService, _clientOptions.CurrentValue.GalleryMaxConcurrentRequests, ct);
                 // commit the transaction
                 currentProcessStep = "Gallery - commit transaction";
-                await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Commit to Gallery", null, ct);
                 await blueprintContext.Database.CommitTransactionAsync(ct);
             }
             catch (System.Exception ex)
             {
                 _logger.LogError(ex, $"{currentProcessStep} ({msel.Id})");
-                await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, $"{msel.Id},ERROR: {currentProcessStep} failed - {ex.Message}", null, ct);
                 throw;
             }
         }
 
         private async STT.Task SteamfitterProcess(MselEntity msel, SteamfitterApiClient steamfitterApiClient, BlueprintContext blueprintContext, CancellationToken ct)
         {
-            var currentProcessStep = "Steamfitter - get hubGroup";
-            var hubGroup = _hubContext.Clients.Group(msel.Id.ToString());
+            var currentProcessStep = "Steamfitter - create scenario";
             try
             {
                 // create the Steamfitter Scenario
-                currentProcessStep = "Steamfitter - create scenario";
-                await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, msel.Id + ",Pushing Scenario to Steamfitter", null, ct);
+                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Scenario to Steamfitter", ct);
                 var scenario = await IntegrationSteamfitterExtensions.CreateScenarioAsync(msel, steamfitterApiClient, blueprintContext, ct);
                 // create the scenario tasks
                 var sortedScenarioEvents = msel.ScenarioEvents.OrderBy(m => m.DeltaSeconds).ToList();
@@ -512,7 +625,6 @@ namespace Blueprint.Api.Services
             catch (System.Exception ex)
             {
                 _logger.LogError(ex, $"{currentProcessStep} ({msel.Id})");
-                await hubGroup.SendAsync(MainHubMethods.MselPushStatusChange, $"{msel.Id},ERROR: {currentProcessStep} failed - {ex.Message}", null, ct);
                 throw;
             }
         }
@@ -555,6 +667,7 @@ namespace Blueprint.Api.Services
     {
         public Guid MselId { get; set; }
         public Guid? PlayerViewId { get; set; }
+        public bool IsPush { get; set; }
         public Data.Enumerations.MselItemStatus FinalStatus { get; set; }
     }
 

--- a/Blueprint.Api/Services/IntegrationService.cs
+++ b/Blueprint.Api/Services/IntegrationService.cs
@@ -20,6 +20,8 @@ using Player.Api.Client;
 using Steamfitter.Api.Client;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AspNetCore.SignalR;
+using Blueprint.Api.Hubs;
 
 
 namespace Blueprint.Api.Services
@@ -36,6 +38,7 @@ namespace Blueprint.Api.Services
         private readonly IIntegrationQueue _integrationQueue;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly IOptionsMonitor<Infrastructure.Options.ClientOptions> _clientOptions;
+        private readonly IHubContext<MainHub> _mainHub;
         private readonly ConcurrentDictionary<Guid, CancellationTokenSource> _cancellationTokenSources = new();
 
         public IntegrationService(
@@ -43,13 +46,15 @@ namespace Blueprint.Api.Services
             IServiceScopeFactory scopeFactory,
             IIntegrationQueue integrationQueue,
             IHttpClientFactory httpClientFactory,
-            IOptionsMonitor<Infrastructure.Options.ClientOptions> clientOptions)
+            IOptionsMonitor<Infrastructure.Options.ClientOptions> clientOptions,
+            IHubContext<MainHub> mainHub)
         {
             _logger = logger;
             _scopeFactory = scopeFactory;
             _integrationQueue = integrationQueue;
             _httpClientFactory = httpClientFactory;
             _clientOptions = clientOptions;
+            _mainHub = mainHub;
         }
 
         public STT.Task StartAsync(CancellationToken cancellationToken)
@@ -72,41 +77,128 @@ namespace Blueprint.Api.Services
                 _ = PerformCancelCleanupAsync(mselId);
         }
 
+        /// <summary>
+        /// Performs cancel cleanup using only ExecuteUpdateAsync and external API calls.
+        /// Never calls SaveChangesAsync, which avoids the EntityEventInterceptor → MediatR →
+        /// SignalR notification chain that can hang on slow/saturated browser connections.
+        /// </summary>
         private async STT.Task PerformCancelCleanupAsync(Guid mselId)
         {
             _logger.LogInformation($"Integration push cancelled for MSEL {mselId}. Starting cleanup.");
             var freshCt = new CancellationToken();
             try
             {
-                // Use a fresh scope and context - the original may be in a bad state after cancellation.
-                using var cleanupScope = _scopeFactory.CreateScope();
-                using var cleanupContext = cleanupScope.ServiceProvider.GetRequiredService<BlueprintContext>();
-                var freshMsel = await cleanupContext.Msels
-                    .Include(m => m.PlayerApplications).ThenInclude(pa => pa.PlayerApplicationTeams)
-                    .Include(m => m.Cards)
-                    .Include(m => m.DataFields)
-                    .Include(m => m.ScenarioEvents).ThenInclude(se => se.DataValues)
-                    .Include(m => m.ScenarioEvents).ThenInclude(se => se.SteamfitterTask)
-                    .Include(m => m.Moves)
-                    .Include(m => m.CiteActions)
-                    .Include(m => m.CiteDuties)
-                    .Include(m => m.Teams).ThenInclude(t => t.TeamUsers).ThenInclude(tu => tu.User)
-                    .Include(m => m.Teams).ThenInclude(t => t.UserTeamRoles)
-                    .AsSplitQuery()
+                using var scope = _scopeFactory.CreateScope();
+                using var dbContext = scope.ServiceProvider.GetRequiredService<BlueprintContext>();
+
+                // Step 1: Update status directly via ExecuteUpdateAsync (bypasses EF tracking/interceptor).
+                var cancelStatus = "Cancelling - removing partial integrations";
+                var updated = await dbContext.Msels
+                    .Where(m => m.Id == mselId)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(m => m.Status, Data.Enumerations.MselItemStatus.Pulling)
+                        .SetProperty(m => m.IntegrationStatus, cancelStatus),
+                        freshCt);
+                _logger.LogInformation($"Cancel cleanup: status update affected {updated} row(s) for MSEL {mselId}.");
+                // Send lightweight SignalR notification for cancel progress
+                await _mainHub.Clients.Group(mselId.ToString())
+                    .SendAsync(MainHubMethods.IntegrationStatusUpdated, mselId, cancelStatus, freshCt);
+                await _mainHub.Clients.Group(MainHub.ADMIN_DATA_GROUP)
+                    .SendAsync(MainHubMethods.IntegrationStatusUpdated, mselId, cancelStatus, freshCt);
+
+                // Step 2: Load MSEL AsNoTracking — we only need the integration IDs for API delete calls.
+                var msel = await dbContext.Msels
+                    .AsNoTracking()
                     .FirstOrDefaultAsync(m => m.Id == mselId, freshCt);
-                if (freshMsel != null)
+
+                if (msel == null)
                 {
-                    freshMsel.Status = Data.Enumerations.MselItemStatus.Pulling;
-                    await UpdateIntegrationStatusAsync(freshMsel, cleanupContext, "Cancelling - removing partial integrations", freshCt);
-                    var tokenResponse = await ApiClientsExtensions.GetToken(cleanupScope);
-                    var pullInfo = new IntegrationInformation
-                    {
-                        MselId = mselId,
-                        IsPush = false,
-                        FinalStatus = Data.Enumerations.MselItemStatus.Approved
-                    };
-                    await PullIntegrations(freshMsel, pullInfo, cleanupContext, tokenResponse, freshCt);
+                    _logger.LogWarning($"Cancel cleanup: MSEL {mselId} not found in database.");
+                    return;
                 }
+
+                _logger.LogInformation($"Cancel cleanup: MSEL {mselId} loaded. PlayerViewId={msel.PlayerViewId}, GalleryCollectionId={msel.GalleryCollectionId}, CiteEvaluationId={msel.CiteEvaluationId}, SteamfitterScenarioId={msel.SteamfitterScenarioId}");
+
+                // Step 3: Get auth token for external API calls.
+                var tokenResponse = await ApiClientsExtensions.GetToken(scope);
+                _logger.LogInformation($"Cancel cleanup: token acquired for MSEL {mselId}. Starting external pulls.");
+
+                // Step 4: Call external API deletes directly (no BlueprintContext/SaveChanges needed).
+                if (msel.SteamfitterScenarioId != null)
+                {
+                    try
+                    {
+                        _logger.LogInformation($"Cancel cleanup: pulling Steamfitter scenario for MSEL {mselId}.");
+                        var steamfitterApiClient = IntegrationSteamfitterExtensions.GetSteamfitterApiClient(_httpClientFactory, _clientOptions.CurrentValue.SteamfitterApiUrl, tokenResponse);
+                        await IntegrationSteamfitterExtensions.PullFromSteamfitterAsync((Guid)msel.SteamfitterScenarioId, steamfitterApiClient, freshCt);
+                    }
+                    catch (System.Exception ex)
+                    {
+                        _logger.LogError(ex, $"Cancel cleanup: Steamfitter pull failed ({mselId})");
+                    }
+                }
+
+                if (msel.CiteEvaluationId != null)
+                {
+                    try
+                    {
+                        _logger.LogInformation($"Cancel cleanup: pulling CITE evaluation for MSEL {mselId}.");
+                        var citeApiClient = IntegrationCiteExtensions.GetCiteApiClient(_httpClientFactory, _clientOptions.CurrentValue.CiteApiUrl, tokenResponse);
+                        await IntegrationCiteExtensions.PullFromCiteAsync((Guid)msel.CiteEvaluationId, citeApiClient, freshCt);
+                    }
+                    catch (System.Exception ex)
+                    {
+                        _logger.LogError(ex, $"Cancel cleanup: CITE pull failed ({mselId})");
+                    }
+                }
+
+                if (msel.GalleryCollectionId != null)
+                {
+                    try
+                    {
+                        _logger.LogInformation($"Cancel cleanup: pulling Gallery collection for MSEL {mselId}.");
+                        var galleryApiClient = IntegrationGalleryExtensions.GetGalleryApiClient(_httpClientFactory, _clientOptions.CurrentValue.GalleryApiUrl, tokenResponse);
+                        await IntegrationGalleryExtensions.PullFromGalleryAsync((Guid)msel.GalleryCollectionId, galleryApiClient, freshCt);
+                    }
+                    catch (System.Exception ex)
+                    {
+                        _logger.LogError(ex, $"Cancel cleanup: Gallery pull failed ({mselId})");
+                    }
+                }
+
+                if (msel.PlayerViewId != null)
+                {
+                    try
+                    {
+                        _logger.LogInformation($"Cancel cleanup: pulling Player view for MSEL {mselId}.");
+                        var playerApiClient = IntegrationPlayerExtensions.GetPlayerApiClient(_httpClientFactory, _clientOptions.CurrentValue.PlayerApiUrl, tokenResponse);
+                        await IntegrationPlayerExtensions.PullFromPlayerAsync((Guid)msel.PlayerViewId, playerApiClient, freshCt);
+                        await IntegrationPlayerExtensions.PullFromPlayerAsync((Guid)msel.PlayerViewId, playerApiClient, freshCt);
+                    }
+                    catch (System.Exception ex)
+                    {
+                        _logger.LogError(ex, $"Cancel cleanup: Player pull failed ({mselId})");
+                    }
+                }
+
+                // Step 5: Use a fresh scope/context for completion so SaveChangesAsync triggers
+                // the full MselUpdated SignalR notification with minimal tracked entities.
+                _logger.LogInformation($"Cancel cleanup: clearing integration IDs for MSEL {mselId}.");
+                using (var finalScope = _scopeFactory.CreateScope())
+                using (var finalContext = finalScope.ServiceProvider.GetRequiredService<BlueprintContext>())
+                {
+                    var finalMsel = await finalContext.Msels.FindAsync(new object[] { mselId }, freshCt);
+                    finalMsel.PlayerViewId = null;
+                    finalMsel.GalleryExhibitId = null;
+                    finalMsel.GalleryCollectionId = null;
+                    finalMsel.CiteEvaluationId = null;
+                    finalMsel.SteamfitterScenarioId = null;
+                    finalMsel.IntegrationStatus = null;
+                    finalMsel.Status = Data.Enumerations.MselItemStatus.Approved;
+                    await finalContext.SaveChangesAsync(freshCt);
+                }
+
+                _logger.LogInformation($"Cancel cleanup: complete for MSEL {mselId}.");
             }
             catch (System.Exception cleanupEx)
             {
@@ -115,9 +207,16 @@ namespace Blueprint.Api.Services
                 {
                     using var errorScope = _scopeFactory.CreateScope();
                     using var errorContext = errorScope.ServiceProvider.GetRequiredService<BlueprintContext>();
-                    var errorMsel = await errorContext.Msels.FindAsync(mselId);
-                    if (errorMsel != null)
-                        await UpdateIntegrationStatusAsync(errorMsel, errorContext, $"ERROR: Cancellation cleanup failed - {cleanupEx.Message}", freshCt);
+                    var errorStatus = $"ERROR: Cancellation cleanup failed - {cleanupEx.Message}";
+                    await errorContext.Msels
+                        .Where(m => m.Id == mselId)
+                        .ExecuteUpdateAsync(s => s
+                            .SetProperty(m => m.IntegrationStatus, errorStatus),
+                            freshCt);
+                    await _mainHub.Clients.Group(mselId.ToString())
+                        .SendAsync(MainHubMethods.IntegrationStatusUpdated, mselId, errorStatus, freshCt);
+                    await _mainHub.Clients.Group(MainHub.ADMIN_DATA_GROUP)
+                        .SendAsync(MainHubMethods.IntegrationStatusUpdated, mselId, errorStatus, freshCt);
                 }
                 catch { /* best effort */ }
             }
@@ -161,6 +260,7 @@ namespace Blueprint.Api.Services
             var ct = cts.Token;
             var currentProcessStep = "Begin processing";
             _logger.LogDebug($"{currentProcessStep} {integrationInformation.MselId}");
+            Guid? cancelledMselId = null;
             try
             {
                 using (var scope = _scopeFactory.CreateScope())
@@ -207,14 +307,6 @@ namespace Blueprint.Api.Services
                                 msel.CiteEvaluationId = Guid.NewGuid();
                             if (msel.UseSteamfitter && msel.SteamfitterScenarioId == null)
                                 msel.SteamfitterScenarioId = Guid.NewGuid();
-
-                            // Pre-set team IDs to match Blueprint team IDs
-                            foreach (var team in msel.Teams)
-                            {
-                                if (msel.UsePlayer) team.PlayerTeamId = team.Id;
-                                if (msel.UseGallery) team.GalleryTeamId = team.Id;
-                                if (msel.UseCite && team.CiteTeamTypeId != null) team.CiteTeamId = team.Id;
-                            }
 
                             await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Integrations", ct);
                         }
@@ -291,17 +383,20 @@ namespace Blueprint.Api.Services
                             if (msel.UsePlayer)
                             {
                                 ct.ThrowIfCancellationRequested();
-                                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Player Applications", ct);
+                                await SendIntegrationStatusAsync(blueprintContext, msel.Id, "Pushing Player Applications", ct);
                                 currentProcessStep = "Player - push applications";
                                 await IntegrationPlayerExtensions.CreateApplicationsAsync(msel, playerApiClient, blueprintContext, _clientOptions.CurrentValue.PlayerMaxConcurrentRequests, _clientOptions.CurrentValue, ct);
                             }
-                            // set the MSEL status
-                            msel.IntegrationStatus = null;
-                            msel.Status = Data.Enumerations.MselItemStatus.Deployed;
-                            await blueprintContext.SaveChangesAsync(ct);
-
-                            // Clear tracked entities to prevent accumulation across operations
-                            blueprintContext.ChangeTracker.Clear();
+                            // Use a fresh scope/context for completion so SaveChangesAsync triggers
+                            // the full MselUpdated SignalR notification with minimal tracked entities.
+                            using (var finalScope = _scopeFactory.CreateScope())
+                            using (var finalContext = finalScope.ServiceProvider.GetRequiredService<BlueprintContext>())
+                            {
+                                var finalMsel = await finalContext.Msels.FindAsync(new object[] { msel.Id }, ct);
+                                finalMsel.Status = Data.Enumerations.MselItemStatus.Deployed;
+                                finalMsel.IntegrationStatus = null;
+                                await finalContext.SaveChangesAsync(ct);
+                            }
                         }
                         else
                         {
@@ -311,29 +406,35 @@ namespace Blueprint.Api.Services
                     }
                     catch (OperationCanceledException)
                     {
-                        // Rollback any open transaction to release DB row locks before cleanup.
-                        // GalleryProcess opens a transaction on blueprintContext; if cancelled mid-flight,
-                        // that transaction holds a lock on the msels row that PerformCancelCleanupAsync needs.
-                        if (blueprintContext.Database.CurrentTransaction != null)
-                        {
-                            try { await blueprintContext.Database.RollbackTransactionAsync(); }
-                            catch { /* best effort */ }
-                        }
-                        await PerformCancelCleanupAsync(msel.Id);
+                        // Capture the ID; cleanup runs after the using block disposes
+                        // blueprintContext (releasing any open transaction/row locks).
+                        cancelledMselId = msel.Id;
                     }
                     catch (System.Exception ex)
                     {
                         _logger.LogError(ex, $"{currentProcessStep} ({msel.Id})");
                         var freshCt = new CancellationToken();
-                        await UpdateIntegrationStatusAsync(msel, blueprintContext, $"ERROR: {currentProcessStep} failed - {ex.Message}", freshCt);
+                        var errorStatus = $"ERROR: {currentProcessStep} failed - {ex.Message}";
+                        // Use ExecuteUpdateAsync + direct SignalR for error (don't risk SaveChangesAsync in error recovery)
+                        await blueprintContext.Msels
+                            .Where(m => m.Id == msel.Id)
+                            .ExecuteUpdateAsync(s => s.SetProperty(m => m.IntegrationStatus, errorStatus), freshCt);
+                        await _mainHub.Clients.Group(msel.Id.ToString())
+                            .SendAsync(MainHubMethods.IntegrationStatusUpdated, msel.Id, errorStatus, freshCt);
+                        await _mainHub.Clients.Group(MainHub.ADMIN_DATA_GROUP)
+                            .SendAsync(MainHubMethods.IntegrationStatusUpdated, msel.Id, errorStatus, freshCt);
                     }
 
                 }
+                // blueprintContext is fully disposed here — all DB locks released.
+                // Safe to run cleanup now without hitting a lock wait on msels.
+                if (cancelledMselId.HasValue)
+                    await PerformCancelCleanupAsync(cancelledMselId.Value);
             }
             catch (System.Exception ex)
             {
                 _logger.LogError(ex, $"{currentProcessStep} {integrationInformation}");
-                // Try to update integration status with error in a fresh context
+                // Try to update integration status with error via ExecuteUpdateAsync + direct SignalR
                 try
                 {
                     using var scope = _scopeFactory.CreateScope();
@@ -341,12 +442,15 @@ namespace Blueprint.Api.Services
                     var mselId = integrationInformation?.MselId ?? Guid.Empty;
                     if (mselId != Guid.Empty)
                     {
-                        var msel = await blueprintContext.Msels.FindAsync(mselId);
-                        if (msel != null)
-                        {
-                            msel.IntegrationStatus = $"ERROR: {currentProcessStep} failed - {ex.Message}";
-                            await blueprintContext.SaveChangesAsync();
-                        }
+                        var errorStatus = $"ERROR: {currentProcessStep} failed - {ex.Message}";
+                        await blueprintContext.Msels
+                            .Where(m => m.Id == mselId)
+                            .ExecuteUpdateAsync(s => s
+                                .SetProperty(m => m.IntegrationStatus, errorStatus));
+                        await _mainHub.Clients.Group(mselId.ToString())
+                            .SendAsync(MainHubMethods.IntegrationStatusUpdated, mselId, errorStatus);
+                        await _mainHub.Clients.Group(MainHub.ADMIN_DATA_GROUP)
+                            .SendAsync(MainHubMethods.IntegrationStatusUpdated, mselId, errorStatus);
                     }
                 }
                 catch (System.Exception innerEx)
@@ -361,11 +465,16 @@ namespace Blueprint.Api.Services
             }
         }
 
+        /// <summary>
+        /// Pulls (deletes) integrations from external services and clears integration IDs.
+        /// Uses ExecuteUpdateAsync for all DB writes to avoid the EntityEventInterceptor →
+        /// MediatR → SignalR chain that can hang on slow/saturated browser connections.
+        /// </summary>
         private async STT.Task PullIntegrations(MselEntity msel, IntegrationInformation integrationInformation, BlueprintContext blueprintContext, IdentityModel.Client.TokenResponse tokenResponse, CancellationToken ct)
         {
+            var mselId = msel.Id;
             var currentProcessStep = "Pulling Integrations";
-            await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pulling Integrations", ct);
-            PlayerApiClient playerApiClient = null;
+            await SendIntegrationStatusAsync(blueprintContext, mselId, "Pulling Integrations", ct);
 
             // Pull from Steamfitter
             if (msel.SteamfitterScenarioId != null)
@@ -373,7 +482,7 @@ namespace Blueprint.Api.Services
                 try
                 {
                     currentProcessStep = "Steamfitter - pull scenario";
-                    await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pulling Steamfitter Scenario", ct);
+                    await SendIntegrationStatusAsync(blueprintContext, mselId, "Pulling Steamfitter Scenario", ct);
                     var steamfitterApiClient = IntegrationSteamfitterExtensions.GetSteamfitterApiClient(_httpClientFactory, _clientOptions.CurrentValue.SteamfitterApiUrl, tokenResponse);
                     await IntegrationSteamfitterExtensions.PullFromSteamfitterAsync((Guid)msel.SteamfitterScenarioId, steamfitterApiClient, ct);
                 }
@@ -388,7 +497,7 @@ namespace Blueprint.Api.Services
                 try
                 {
                     currentProcessStep = "CITE - pull evaluation";
-                    await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pulling CITE Evaluation", ct);
+                    await SendIntegrationStatusAsync(blueprintContext, mselId, "Pulling CITE Evaluation", ct);
                     var citeApiClient = IntegrationCiteExtensions.GetCiteApiClient(_httpClientFactory, _clientOptions.CurrentValue.CiteApiUrl, tokenResponse);
                     await IntegrationCiteExtensions.PullFromCiteAsync((Guid)msel.CiteEvaluationId, citeApiClient, ct);
                 }
@@ -403,7 +512,7 @@ namespace Blueprint.Api.Services
                 try
                 {
                     currentProcessStep = "Gallery - pull collection";
-                    await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pulling Gallery Collection", ct);
+                    await SendIntegrationStatusAsync(blueprintContext, mselId, "Pulling Gallery Collection", ct);
                     var galleryApiClient = IntegrationGalleryExtensions.GetGalleryApiClient(_httpClientFactory, _clientOptions.CurrentValue.GalleryApiUrl, tokenResponse);
                     await IntegrationGalleryExtensions.PullFromGalleryAsync((Guid)msel.GalleryCollectionId, galleryApiClient, ct);
                 }
@@ -418,8 +527,8 @@ namespace Blueprint.Api.Services
                 try
                 {
                     currentProcessStep = "Player - pull view";
-                    await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pulling Player View", ct);
-                    playerApiClient = IntegrationPlayerExtensions.GetPlayerApiClient(_httpClientFactory, _clientOptions.CurrentValue.PlayerApiUrl, tokenResponse);
+                    await SendIntegrationStatusAsync(blueprintContext, mselId, "Pulling Player View", ct);
+                    var playerApiClient = IntegrationPlayerExtensions.GetPlayerApiClient(_httpClientFactory, _clientOptions.CurrentValue.PlayerApiUrl, tokenResponse);
                     // TODO:  Player requires two deletes?
                     await IntegrationPlayerExtensions.PullFromPlayerAsync((Guid)msel.PlayerViewId, playerApiClient, ct);
                     await IntegrationPlayerExtensions.PullFromPlayerAsync((Guid)msel.PlayerViewId, playerApiClient, ct);
@@ -429,32 +538,42 @@ namespace Blueprint.Api.Services
                     _logger.LogError(ex, $"{currentProcessStep} ({msel.Id})");
                 }
             }
-            // update the MSEL
+            // Use a fresh scope/context for completion so SaveChangesAsync triggers
+            // the full MselUpdated SignalR notification with minimal tracked entities.
             currentProcessStep = "MSEL update";
-            var mselId = msel.Id;
-            msel = await blueprintContext.Msels.FirstOrDefaultAsync(m => m.Id == mselId);
-            if (msel != null)
+            using (var finalScope = _scopeFactory.CreateScope())
+            using (var finalContext = finalScope.ServiceProvider.GetRequiredService<BlueprintContext>())
             {
-                msel.CiteEvaluationId = null;
-                msel.GalleryExhibitId = null;
-                msel.GalleryCollectionId = null;
-                msel.PlayerViewId = null;
-                msel.SteamfitterScenarioId = null;
-                // Clear team integration IDs
-                var teams = await blueprintContext.Teams.Where(t => t.MselId == mselId).ToListAsync(ct);
-                foreach (var team in teams)
-                {
-                    team.PlayerTeamId = null;
-                    team.GalleryTeamId = null;
-                    team.CiteTeamId = null;
-                }
-                msel.IntegrationStatus = null;
-                msel.Status = integrationInformation.FinalStatus;
-                await blueprintContext.SaveChangesAsync(ct);
+                var finalMsel = await finalContext.Msels.FindAsync(new object[] { mselId }, ct);
+                finalMsel.PlayerViewId = null;
+                finalMsel.GalleryExhibitId = null;
+                finalMsel.GalleryCollectionId = null;
+                finalMsel.CiteEvaluationId = null;
+                finalMsel.SteamfitterScenarioId = null;
+                finalMsel.IntegrationStatus = null;
+                finalMsel.Status = integrationInformation.FinalStatus;
+                await finalContext.SaveChangesAsync(ct);
             }
+        }
 
-            // Clear tracked entities to prevent accumulation across operations
-            blueprintContext.ChangeTracker.Clear();
+        /// <summary>
+        /// Updates the IntegrationStatus field via ExecuteUpdateAsync (bypasses EF tracking/interceptor)
+        /// and sends a lightweight SignalR notification directly to connected clients.
+        /// </summary>
+        private async STT.Task SendIntegrationStatusAsync(BlueprintContext blueprintContext, Guid mselId, string status, CancellationToken ct)
+        {
+            // Persist to DB (bypasses interceptor/SignalR)
+            await blueprintContext.Msels
+                .Where(m => m.Id == mselId)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(m => m.IntegrationStatus, status),
+                    ct);
+
+            // Send lightweight SignalR notification directly
+            await _mainHub.Clients.Group(mselId.ToString())
+                .SendAsync(MainHubMethods.IntegrationStatusUpdated, mselId, status, ct);
+            await _mainHub.Clients.Group(MainHub.ADMIN_DATA_GROUP)
+                .SendAsync(MainHubMethods.IntegrationStatusUpdated, mselId, status, ct);
         }
 
         private bool CanMselBePushed(MselEntity mselToIntegrate)
@@ -469,11 +588,11 @@ namespace Blueprint.Api.Services
             try
             {
                 // create the Player View
-                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing View to Player", ct);
+                await SendIntegrationStatusAsync(blueprintContext, msel.Id, "Pushing View to Player", ct);
                 await IntegrationPlayerExtensions.CreateViewAsync(msel, playerViewId, playerApiClient, blueprintContext, ct);
                 // create the Player Teams
                 currentProcessStep = "Player create teams";
-                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Teams to Player", ct);
+                await SendIntegrationStatusAsync(blueprintContext, msel.Id, "Pushing Teams to Player", ct);
                 await IntegrationPlayerExtensions.CreateTeamsAsync(msel, playerApiClient, blueprintContext, playerUserIds, ct);
             }
             catch (System.Exception ex)
@@ -489,27 +608,27 @@ namespace Blueprint.Api.Services
             try
             {
                 // create the Cite Evaluation
-                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Evaluation to CITE", ct);
+                await SendIntegrationStatusAsync(blueprintContext, msel.Id, "Pushing Evaluation to CITE", ct);
                 var evaluation = await IntegrationCiteExtensions.CreateEvaluationAsync(msel, citeApiClient, blueprintContext, ct);
                 // create the Cite Moves
                 currentProcessStep = "CITE - create moves";
-                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Moves to CITE", ct);
+                await SendIntegrationStatusAsync(blueprintContext, msel.Id, "Pushing Moves to CITE", ct);
                 await IntegrationCiteExtensions.CreateMovesAsync(msel, citeApiClient, blueprintContext, _clientOptions.CurrentValue.CiteMaxConcurrentRequests, ct);
                 // create the Cite Teams
                 currentProcessStep = "CITE - create teams";
-                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Teams to CITE", ct);
+                await SendIntegrationStatusAsync(blueprintContext, msel.Id, "Pushing Teams to CITE", ct);
                 await IntegrationCiteExtensions.CreateTeamsAsync(msel, citeApiClient, blueprintContext, citeUserIds, ct);
                 // create the Cite Duties
                 currentProcessStep = "CITE - create duties";
-                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Duties to CITE", ct);
+                await SendIntegrationStatusAsync(blueprintContext, msel.Id, "Pushing Duties to CITE", ct);
                 await IntegrationCiteExtensions.CreateDutiesAsync(msel, citeApiClient, blueprintContext, _clientOptions.CurrentValue.CiteMaxConcurrentRequests, ct);
                 // create the Cite Actions
                 currentProcessStep = "CITE - create actions";
-                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Actions to CITE", ct);
+                await SendIntegrationStatusAsync(blueprintContext, msel.Id, "Pushing Actions to CITE", ct);
                 await IntegrationCiteExtensions.CreateActionsAsync(msel, citeApiClient, blueprintContext, _clientOptions.CurrentValue.CiteMaxConcurrentRequests, ct);
                 // update the evaluation, so that submissions get created
                 currentProcessStep = "CITE - advance";
-                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Finishing Evaluation to CITE", ct);
+                await SendIntegrationStatusAsync(blueprintContext, msel.Id, "Finishing Evaluation to CITE", ct);
                 evaluation.Status = Cite.Api.Client.ItemStatus.Active;
                 await IntegrationCiteExtensions.ActivateAsync(evaluation, citeApiClient, blueprintContext, ct);
             }
@@ -522,34 +641,29 @@ namespace Blueprint.Api.Services
 
         private async STT.Task GalleryProcess(MselEntity msel, IScenarioEventService scenarioEventService, GalleryApiClient galleryApiClient, BlueprintContext blueprintContext, HashSet<Guid> galleryUserIds, CancellationToken ct)
         {
-            var currentProcessStep = "Gallery - begin transaction";
+            var currentProcessStep = "Gallery - Pushing Collection";
             try
             {
-                // start a transaction, because we will modify many database items
-                await blueprintContext.Database.BeginTransactionAsync();
                 // create the Gallery Collection
-                currentProcessStep = "Gallery - Pushing Collection";
-                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Collection to Gallery", ct);
+                await SendIntegrationStatusAsync(blueprintContext, msel.Id, "Pushing Collection to Gallery", ct);
                 await IntegrationGalleryExtensions.CreateCollectionAsync(msel, galleryApiClient, blueprintContext, ct);
                 // create the Gallery Exhibit
                 currentProcessStep = "Gallery - Pushing Exhibit";
-                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Exhibit to Gallery", ct);
+                await SendIntegrationStatusAsync(blueprintContext, msel.Id, "Pushing Exhibit to Gallery", ct);
                 await IntegrationGalleryExtensions.CreateExhibitAsync(msel, galleryApiClient, blueprintContext, ct);
                 // create the Gallery Teams
                 currentProcessStep = "Gallery - Pushing Teams";
-                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Teams to Gallery", ct);
+                await SendIntegrationStatusAsync(blueprintContext, msel.Id, "Pushing Teams to Gallery", ct);
                 await IntegrationGalleryExtensions.CreateTeamsAsync(msel, galleryApiClient, blueprintContext, galleryUserIds, ct);
                 // create the Gallery Cards
                 currentProcessStep = "Gallery - Pushing Cards";
-                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Cards to Gallery", ct);
+                await SendIntegrationStatusAsync(blueprintContext, msel.Id, "Pushing Cards to Gallery", ct);
                 await IntegrationGalleryExtensions.CreateCardsAsync(msel, galleryApiClient, blueprintContext, _clientOptions.CurrentValue.GalleryMaxConcurrentRequests, ct);
                 // create the Gallery Articles
                 currentProcessStep = "Gallery - Pushing Articles";
-                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Articles to Gallery", ct);
+                await SendIntegrationStatusAsync(blueprintContext, msel.Id, "Pushing Articles to Gallery", ct);
                 await IntegrationGalleryExtensions.CreateArticlesAsync(msel, galleryApiClient, blueprintContext, scenarioEventService, _clientOptions.CurrentValue.GalleryMaxConcurrentRequests, ct);
-                // commit the transaction
-                currentProcessStep = "Gallery - commit transaction";
-                await blueprintContext.Database.CommitTransactionAsync(ct);
+                currentProcessStep = "Gallery - done";
             }
             catch (System.Exception ex)
             {
@@ -564,7 +678,7 @@ namespace Blueprint.Api.Services
             try
             {
                 // create the Steamfitter Scenario
-                await UpdateIntegrationStatusAsync(msel, blueprintContext, "Pushing Scenario to Steamfitter", ct);
+                await SendIntegrationStatusAsync(blueprintContext, msel.Id, "Pushing Scenario to Steamfitter", ct);
                 var scenario = await IntegrationSteamfitterExtensions.CreateScenarioAsync(msel, steamfitterApiClient, blueprintContext, ct);
                 // create the scenario tasks
                 var sortedScenarioEvents = msel.ScenarioEvents.OrderBy(m => m.DeltaSeconds).ToList();

--- a/Blueprint.Api/Services/IntegrationService.cs
+++ b/Blueprint.Api/Services/IntegrationService.cs
@@ -128,7 +128,7 @@ namespace Blueprint.Api.Services
                 {
                     try
                     {
-                        _logger.LogInformation($"Cancel cleanup: pulling Steamfitter scenario for MSEL {mselId}.");
+                        await SendIntegrationStatusAsync(dbContext, mselId, "Cancelling - pulling Steamfitter Scenario", freshCt);
                         var steamfitterApiClient = IntegrationSteamfitterExtensions.GetSteamfitterApiClient(_httpClientFactory, _clientOptions.CurrentValue.SteamfitterApiUrl, tokenResponse);
                         await IntegrationSteamfitterExtensions.PullFromSteamfitterAsync((Guid)msel.SteamfitterScenarioId, steamfitterApiClient, freshCt);
                     }
@@ -142,7 +142,7 @@ namespace Blueprint.Api.Services
                 {
                     try
                     {
-                        _logger.LogInformation($"Cancel cleanup: pulling CITE evaluation for MSEL {mselId}.");
+                        await SendIntegrationStatusAsync(dbContext, mselId, "Cancelling - pulling CITE Evaluation", freshCt);
                         var citeApiClient = IntegrationCiteExtensions.GetCiteApiClient(_httpClientFactory, _clientOptions.CurrentValue.CiteApiUrl, tokenResponse);
                         await IntegrationCiteExtensions.PullFromCiteAsync((Guid)msel.CiteEvaluationId, citeApiClient, freshCt);
                     }
@@ -156,7 +156,7 @@ namespace Blueprint.Api.Services
                 {
                     try
                     {
-                        _logger.LogInformation($"Cancel cleanup: pulling Gallery collection for MSEL {mselId}.");
+                        await SendIntegrationStatusAsync(dbContext, mselId, "Cancelling - pulling Gallery Collection", freshCt);
                         var galleryApiClient = IntegrationGalleryExtensions.GetGalleryApiClient(_httpClientFactory, _clientOptions.CurrentValue.GalleryApiUrl, tokenResponse);
                         await IntegrationGalleryExtensions.PullFromGalleryAsync((Guid)msel.GalleryCollectionId, galleryApiClient, freshCt);
                     }
@@ -170,7 +170,7 @@ namespace Blueprint.Api.Services
                 {
                     try
                     {
-                        _logger.LogInformation($"Cancel cleanup: pulling Player view for MSEL {mselId}.");
+                        await SendIntegrationStatusAsync(dbContext, mselId, "Cancelling - pulling Player View", freshCt);
                         var playerApiClient = IntegrationPlayerExtensions.GetPlayerApiClient(_httpClientFactory, _clientOptions.CurrentValue.PlayerApiUrl, tokenResponse);
                         await IntegrationPlayerExtensions.PullFromPlayerAsync((Guid)msel.PlayerViewId, playerApiClient, freshCt);
                         await IntegrationPlayerExtensions.PullFromPlayerAsync((Guid)msel.PlayerViewId, playerApiClient, freshCt);

--- a/Blueprint.Api/Services/JoinQueue.cs
+++ b/Blueprint.Api/Services/JoinQueue.cs
@@ -33,9 +33,10 @@ namespace Blueprint.Api.Services
     public class JoinInformation
     {
         public Guid UserId { get; set; }
-        public Guid? PlayerTeamId { get; set; }
-        public Guid? GalleryTeamId { get; set; }
-        public Guid? CiteTeamId { get; set; }
+        public Guid TeamId { get; set; }
+        public bool UsePlayer { get; set; }
+        public bool UseGallery { get; set; }
+        public bool UseCite { get; set; }
     }
 
 }

--- a/Blueprint.Api/Services/JoinService.cs
+++ b/Blueprint.Api/Services/JoinService.cs
@@ -86,7 +86,7 @@ namespace Blueprint.Api.Services
         {
             var ct = new CancellationToken();
             var joinInformation = (JoinInformation)joinInformationObject;
-            var loggerInformation = $"Join for User: {joinInformation.UserId}, PlayerTeam: {joinInformation.PlayerTeamId}";
+            var loggerInformation = $"Join for User: {joinInformation.UserId}, Team: {joinInformation.TeamId}";
             var currentProcessStep = "Begin processing";
             _logger.LogDebug($"{currentProcessStep} {loggerInformation}");
             try
@@ -97,7 +97,7 @@ namespace Blueprint.Api.Services
                     // get auth token
                     var tokenResponse = await ApiClientsExtensions.GetToken(scope);
                     // Join Player
-                    if (joinInformation.PlayerTeamId != null)
+                    if (joinInformation.UsePlayer)
                     {
                         // Get Player API client
                         currentProcessStep = "Player - get API client";
@@ -105,10 +105,10 @@ namespace Blueprint.Api.Services
 
                         // add user to team
                         currentProcessStep = "Player - add user to team";
-                        await IntegrationPlayerExtensions.AddUserToTeamAsync(joinInformation.UserId, (Guid)joinInformation.PlayerTeamId, playerApiClient, blueprintContext, ct);
+                        await IntegrationPlayerExtensions.AddUserToTeamAsync(joinInformation.UserId, joinInformation.TeamId, playerApiClient, blueprintContext, ct);
                     }
                     // Join Gallery
-                    if (joinInformation.GalleryTeamId != null)
+                    if (joinInformation.UseGallery)
                     {
                         // Get Gallery API client
                         currentProcessStep = "Gallery - get API client";
@@ -116,10 +116,10 @@ namespace Blueprint.Api.Services
 
                         // add user to team
                         currentProcessStep = "Gallery - add user to team";
-                        await IntegrationGalleryExtensions.AddUserToTeamAsync(joinInformation.UserId, (Guid)joinInformation.GalleryTeamId, galleryApiClient, blueprintContext, ct);
+                        await IntegrationGalleryExtensions.AddUserToTeamAsync(joinInformation.UserId, joinInformation.TeamId, galleryApiClient, blueprintContext, ct);
                     }
                     // Join Cite
-                    if (joinInformation.CiteTeamId != null)
+                    if (joinInformation.UseCite)
                     {
                         // Get Cite API client
                         currentProcessStep = "Cite - get API client";
@@ -127,7 +127,7 @@ namespace Blueprint.Api.Services
 
                         // add user to team
                         currentProcessStep = "Cite - add user to team";
-                        await IntegrationCiteExtensions.AddUserToTeamAsync(joinInformation.UserId, (Guid)joinInformation.CiteTeamId, citeApiClient, blueprintContext, ct);
+                        await IntegrationCiteExtensions.AddUserToTeamAsync(joinInformation.UserId, joinInformation.TeamId, citeApiClient, blueprintContext, ct);
                     }
                 }
             }

--- a/Blueprint.Api/Services/MselService.cs
+++ b/Blueprint.Api/Services/MselService.cs
@@ -53,6 +53,7 @@ namespace Blueprint.Api.Services
         Task<DataTable> GetDataTableAsync(Guid mselId, CancellationToken ct);
         Task<ViewModels.Msel> PushIntegrationsAsync(Guid mselId, bool hasSystemPermission, CancellationToken ct);
         Task<ViewModels.Msel> PullIntegrationsAsync(Guid mselId, MselItemStatus finalStatus, bool hasSystemPermission, CancellationToken ct);
+        Task CancelIntegrationsAsync(Guid mselId, bool hasSystemPermission, CancellationToken ct);
         Task<ViewModels.Msel> ArchiveAsync(Guid mselId, bool hasSystemPermission, CancellationToken ct);
         Task<IEnumerable<ViewModels.Msel>> GetMyJoinInvitationMselsAsync(CancellationToken ct);
         Task<IEnumerable<ViewModels.Msel>> GetMyLaunchInvitationMselsAsync(CancellationToken ct);
@@ -69,6 +70,7 @@ namespace Blueprint.Api.Services
         private readonly ClientOptions _clientOptions;
         private readonly IScenarioEventService _scenarioEventService;
         private readonly IIntegrationQueue _integrationQueue;
+        private readonly IIntegrationService _integrationService;
         private readonly IPlayerService _playerService;
         private readonly IJoinQueue _joinQueue;
         private readonly IXApiService _xApiService;
@@ -79,6 +81,7 @@ namespace Blueprint.Api.Services
             ClientOptions clientOptions,
             IScenarioEventService scenarioEventService,
             IIntegrationQueue integrationQueue,
+            IIntegrationService integrationService,
             IPlayerService playerService,
             IJoinQueue joinQueue,
             IPrincipal user,
@@ -94,6 +97,7 @@ namespace Blueprint.Api.Services
             _mapper = mapper;
             _logger = logger;
             _integrationQueue = integrationQueue;
+            _integrationService = integrationService;
             _playerService = playerService;
             _joinQueue = joinQueue;
             _xApiService = xApiService;
@@ -1891,7 +1895,9 @@ namespace Blueprint.Api.Services
             var userVerificationErrorMessage = await FindDuplicateMselUsersAsync(mselId, ct);
             if (!String.IsNullOrWhiteSpace(userVerificationErrorMessage))
                 throw new InvalidOperationException(userVerificationErrorMessage);
-            _integrationQueue.Add(new IntegrationInformation { MselId = mselId, PlayerViewId = null, FinalStatus = MselItemStatus.Deployed });
+            msel.Status = MselItemStatus.Pushing;
+            await _context.SaveChangesAsync(ct);
+            _integrationQueue.Add(new IntegrationInformation { MselId = mselId, PlayerViewId = null, IsPush = true, FinalStatus = MselItemStatus.Deployed });
 
             // Track xAPI - Exercise Started
             if (_xApiService.IsConfigured())
@@ -1912,7 +1918,9 @@ namespace Blueprint.Api.Services
             if (msel == null)
                 throw new EntityNotFoundException<MselEntity>($"MSEL {mselId} was not found.");
             // add msel to process queue
-            _integrationQueue.Add(new IntegrationInformation { MselId = mselId, PlayerViewId = null, FinalStatus = finalStatus });
+            msel.Status = MselItemStatus.Pulling;
+            await _context.SaveChangesAsync(ct);
+            _integrationQueue.Add(new IntegrationInformation { MselId = mselId, PlayerViewId = null, IsPush = false, FinalStatus = finalStatus });
 
             // Track xAPI - Exercise Stopped
             if (_xApiService.IsConfigured())
@@ -1921,6 +1929,14 @@ namespace Blueprint.Api.Services
             }
 
             return _mapper.Map<ViewModels.Msel>(msel);
+        }
+
+        public async Task CancelIntegrationsAsync(Guid mselId, bool hasSystemPermission, CancellationToken ct)
+        {
+            // user must be a Content Developer or a MSEL owner
+            if (!hasSystemPermission && !(await MselOwnerRequirement.IsMet(_user.GetId(), mselId, _context)))
+                throw new ForbiddenException();
+            _integrationService.CancelPush(mselId);
         }
 
         public async Task<ViewModels.Msel> ArchiveAsync(Guid mselId, bool hasSystemPermission, CancellationToken ct)
@@ -2179,7 +2195,7 @@ namespace Blueprint.Api.Services
             // create the new player view ID, so that the UI will be able to look for it to be created
             var playerViewId = Guid.NewGuid();
             // add the launch data to the launch queue
-            _integrationQueue.Add(new IntegrationInformation { MselId = mselEntity.Id, PlayerViewId = playerViewId });
+            _integrationQueue.Add(new IntegrationInformation { MselId = mselEntity.Id, PlayerViewId = playerViewId, IsPush = true });
             // get the MSEL to return with the new Player View ID
             var launchedMsel = _mapper.Map<Msel>(mselEntity);
             launchedMsel.PlayerViewId = playerViewId;

--- a/Blueprint.Api/Services/MselService.cs
+++ b/Blueprint.Api/Services/MselService.cs
@@ -2138,9 +2138,10 @@ namespace Blueprint.Api.Services
                 var joinInformation = new JoinInformation
                 {
                     UserId = userId,
-                    PlayerTeamId = invitation.Team.PlayerTeamId,
-                    GalleryTeamId = invitation.Team.GalleryTeamId,
-                    CiteTeamId = invitation.Team.CiteTeamId
+                    TeamId = (Guid)invitation.TeamId,
+                    UsePlayer = msel.UsePlayer,
+                    UseGallery = msel.UseGallery,
+                    UseCite = msel.UseCite && invitation.Team.CiteTeamTypeId != null
                 };
                 _joinQueue.Add(joinInformation);
             }

--- a/Blueprint.Api/Services/PlayerService.cs
+++ b/Blueprint.Api/Services/PlayerService.cs
@@ -104,13 +104,13 @@ namespace Blueprint.Api.Services
                 .Select(t => t.Id)
                 .ToListAsync(ct);
             var userId = _user.GetId();
-            var playerTeamId = await _context.TeamUsers
+            var teamId = await _context.TeamUsers
                 .Where(tu => tu.UserId == userId && mselTeamIds.Contains(tu.TeamId))
-                .Select(tu => tu.Team.PlayerTeamId)
+                .Select(tu => tu.TeamId)
                 .SingleOrDefaultAsync(ct);
             var addApplicationInformation = new AddApplicationInformation{
                 Application = playerApplication,
-                PlayerTeamId = (Guid)playerTeamId,
+                TeamId = teamId,
                 DisplayOrder = msel.PlayerApplications.Count + 1
             };
             _addApplicationQueue.Add(addApplicationInformation);

--- a/Blueprint.Api/Startup.cs
+++ b/Blueprint.Api/Startup.cs
@@ -230,7 +230,9 @@ public class Startup
         services.AddHostedService<Services.XApiBackgroundService>();
 
         services.AddSingleton<IIntegrationQueue, IntegrationQueue>();
-        services.AddHostedService<IntegrationService>();
+        services.AddSingleton<IntegrationService>();
+        services.AddSingleton<IIntegrationService>(sp => sp.GetRequiredService<IntegrationService>());
+        services.AddHostedService(sp => sp.GetRequiredService<IntegrationService>());
         services.AddSingleton<IJoinQueue, JoinQueue>();
         services.AddHostedService<JoinService>();
         services.AddSingleton<IAddApplicationQueue, AddApplicationQueue>();

--- a/Blueprint.Api/ViewModels/Msel.cs
+++ b/Blueprint.Api/ViewModels/Msel.cs
@@ -13,6 +13,7 @@ namespace Blueprint.Api.ViewModels
         public string Name { get; set; }
         public string Description { get; set; }
         public MselItemStatus Status { get; set; }
+        public string IntegrationStatus { get; set; }
         public bool UsePlayer { get; set; }
         public Guid? PlayerViewId { get; set; }
         public IntegrationType PlayerIntegrationType { get; set; }

--- a/Blueprint.Api/ViewModels/Team.cs
+++ b/Blueprint.Api/ViewModels/Team.cs
@@ -14,9 +14,6 @@ namespace Blueprint.Api.ViewModels
         public Guid? MselId { get; set; }
         public Guid? CiteTeamTypeId { get; set; }
         public string Email { get; set; }
-        public Guid? PlayerTeamId { get; set; }
-        public Guid? GalleryTeamId { get; set; }
-        public Guid? CiteTeamId { get; set; }
         public bool canTeamLeaderInvite { get; set; }
         public bool canTeamMemberInvite { get; set; }
         public User[] Users { get; set; }


### PR DESCRIPTION
  - Add IntegrationStatus string field to MSEL for fine-grained progress messages during push/pull operations
  - Add Pushing (35) and Pulling (36) MSEL status enum values set when push/pull is initiated
  - Add EF migration for the new integration_status column
  - Replace Steamfitter.Api.Client NuGet reference with 3.9.9 (adds Id field to ScenarioForm for pre-generated IDs)
  - Implement background IntegrationService with cancellable push queue, cancel/cleanup flow that rolls back open transactions before pulling, and a shared PerformCancelCleanupAsync used by both cancel paths
  - Add cancel integrations endpoint (POST /api/msels/{id}/cancel) and pull integrations endpoint
  - Pre-generate integration object IDs before calling remote APIs so Blueprint knows the IDs before they are created
  - Fix Player view and team creation to accept caller-supplied IDs