### PR TITLE
Fix catalog copy to include related data + add user presence to SignalR hub  

### DIFF
--- a/Blueprint.Api/Hubs/HubCache.cs
+++ b/Blueprint.Api/Hubs/HubCache.cs
@@ -1,0 +1,20 @@
+// Copyright 2024 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license, please see LICENSE.md in the project root for license information or contact permission@sei.cmu.edu for full terms.
+
+using System.Collections.Concurrent;
+
+namespace Blueprint.Api.Hubs
+{
+    public class HubCache
+    {
+        public ConcurrentDictionary<string, CachedConnection> Connections { get; } = new();
+    }
+
+    public class CachedConnection
+    {
+        public string ConnectionId { get; set; }
+        public string MselId { get; set; }
+        public string UserId { get; set; }
+        public string UserName { get; set; }
+    }
+}

--- a/Blueprint.Api/Hubs/MainHub.cs
+++ b/Blueprint.Api/Hubs/MainHub.cs
@@ -26,6 +26,7 @@ namespace Blueprint.Api.Hubs
         private readonly DatabaseOptions _options;
         private readonly CancellationToken _ct;
         private readonly IBlueprintAuthorizationService _blueprintAuthorizationService;
+        private readonly HubCache _hubCache;
         public const string ADMIN_DATA_GROUP = "AdminDataGroup";
         public const string GROUP_GROUP = "AdminGroupGroup";
         public const string ROLE_GROUP = "AdminRoleGroup";
@@ -36,7 +37,8 @@ namespace Blueprint.Api.Hubs
             IMselService mselService,
             BlueprintContext context,
             DatabaseOptions options,
-            IBlueprintAuthorizationService blueprintAuthorizationService
+            IBlueprintAuthorizationService blueprintAuthorizationService,
+            HubCache hubCache
         )
         {
             _teamService = teamService;
@@ -46,6 +48,7 @@ namespace Blueprint.Api.Hubs
             CancellationTokenSource source = new CancellationTokenSource();
             _ct = source.Token;
             _blueprintAuthorizationService = blueprintAuthorizationService;
+            _hubCache = hubCache;
         }
 
         public async Task Join()
@@ -63,19 +66,49 @@ namespace Blueprint.Api.Hubs
         public async Task Leave()
         {
             var userId = Context.User.Identities.First().Claims.First(c => c.Type == "sub")?.Value;
+            var userName = Context.User.Identities.First().Claims.FirstOrDefault(c => c.Type == "name")?.Value ?? "Unknown";
             var idList = await GetMselIdList(userId);
             idList.Add(userId);
             foreach (var id in idList)
             {
                 await Groups.RemoveFromGroupAsync(Context.ConnectionId, id.ToString());
             }
+
+            // broadcast departure if tracked
+            if (_hubCache.Connections.TryRemove(Context.ConnectionId, out var connection) && !string.IsNullOrEmpty(connection.MselId))
+            {
+                await Clients.OthersInGroup(connection.MselId).SendAsync(
+                    MainHubMethods.PresenceDeparted,
+                    new { id = userId, name = userName });
+            }
+        }
+
+        public override async Task OnDisconnectedAsync(Exception exception)
+        {
+            if (_hubCache.Connections.TryRemove(Context.ConnectionId, out var connection) && !string.IsNullOrEmpty(connection.MselId))
+            {
+                await Clients.OthersInGroup(connection.MselId).SendAsync(
+                    MainHubMethods.PresenceDeparted,
+                    new { id = connection.UserId, name = connection.UserName });
+            }
+            await base.OnDisconnectedAsync(exception);
         }
 
         public async Task SelectMsel(Guid[] args)
         {
             // leave all other MSELs
             var userId = Context.User.Identities.First().Claims.First(c => c.Type == "sub")?.Value;
+            var userName = Context.User.Identities.First().Claims.FirstOrDefault(c => c.Type == "name")?.Value ?? "Unknown";
             var idList = await GetMselIdList(userId);
+
+            // depart from previous MSEL presence if tracked
+            if (_hubCache.Connections.TryGetValue(Context.ConnectionId, out var previousConnection) && !string.IsNullOrEmpty(previousConnection.MselId))
+            {
+                await Clients.OthersInGroup(previousConnection.MselId).SendAsync(
+                    MainHubMethods.PresenceDeparted,
+                    new { id = userId, name = userName });
+            }
+
             foreach (var id in idList)
             {
                 await Groups.RemoveFromGroupAsync(Context.ConnectionId, id.ToString());
@@ -87,8 +120,45 @@ namespace Blueprint.Api.Hubs
                 if (idList.Contains(mselId))
                 {
                     await Groups.AddToGroupAsync(Context.ConnectionId, mselId);
+
+                    // track connection and broadcast arrival
+                    _hubCache.Connections[Context.ConnectionId] = new CachedConnection
+                    {
+                        ConnectionId = Context.ConnectionId,
+                        MselId = mselId,
+                        UserId = userId,
+                        UserName = userName
+                    };
+
+                    await Clients.OthersInGroup(mselId).SendAsync(
+                        MainHubMethods.PresenceArrived,
+                        new { id = userId, name = userName });
                 }
             }
+            else
+            {
+                // no MSEL selected, remove from cache
+                _hubCache.Connections.TryRemove(Context.ConnectionId, out _);
+            }
+        }
+
+        public async Task Greet(string mselId)
+        {
+            var userId = Context.User.Identities.First().Claims.First(c => c.Type == "sub")?.Value;
+            var userName = Context.User.Identities.First().Claims.FirstOrDefault(c => c.Type == "name")?.Value ?? "Unknown";
+            await Clients.OthersInGroup(mselId).SendAsync(
+                MainHubMethods.PresenceGreeted,
+                new { id = userId, name = userName });
+        }
+
+        public Task<List<object>> GetPresence(string mselId)
+        {
+            var userId = Context.User.Identities.First().Claims.First(c => c.Type == "sub")?.Value;
+            var result = _hubCache.Connections.Values
+                .Where(c => c.MselId == mselId && c.UserId != userId)
+                .Select(c => (object)new { id = c.UserId, name = c.UserName })
+                .ToList();
+            return Task.FromResult(result);
         }
 
         public async Task JoinAdmin()
@@ -261,5 +331,8 @@ namespace Blueprint.Api.Hubs
         public const string SystemRoleCreated = "SystemRoleCreated";
         public const string SystemRoleUpdated = "SystemRoleUpdated";
         public const string SystemRoleDeleted = "SystemRoleDeleted";
+        public const string PresenceArrived = "PresenceArrived";
+        public const string PresenceDeparted = "PresenceDeparted";
+        public const string PresenceGreeted = "PresenceGreeted";
     }
 }

--- a/Blueprint.Api/Services/CatalogService.cs
+++ b/Blueprint.Api/Services/CatalogService.cs
@@ -141,7 +141,16 @@ namespace Blueprint.Api.Services
         public async Task<ViewModels.Catalog> CopyAsync(Guid catalogId, CancellationToken ct)
         {
             var newCatalogEntity = await _context.Catalogs
+                .Include(m => m.InjectType)
+                    .ThenInclude(m => m.DataFields)
+                        .ThenInclude(m => m.DataOptions)
                 .Include(m => m.CatalogInjects)
+                    .ThenInclude(m => m.Inject)
+                        .ThenInclude(m => m.InjectType)
+                .Include(m => m.CatalogInjects)
+                    .ThenInclude(m => m.Inject)
+                        .ThenInclude(m => m.DataValues)
+                .AsSplitQuery()
                 .AsNoTracking()
                 .SingleOrDefaultAsync(m => m.Id == catalogId);
             newCatalogEntity = await privateCatalogCopyAsync(newCatalogEntity, ct);

--- a/Blueprint.Api/Startup.cs
+++ b/Blueprint.Api/Startup.cs
@@ -220,6 +220,7 @@ public class Startup
         services.AddScoped<IBlueprintAuthorizationService, BlueprintAuthorizationService>();
         services.AddScoped<IIdentityResolver, IdentityResolver>();
         services.AddSingleton<IUserIdProvider, SubUserIdProvider>();
+        services.AddSingleton<Hubs.HubCache>();
         services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
         services.AddScoped<IPrincipal>(p => p.GetService<IHttpContextAccessor>()?.HttpContext?.User);
         services.AddScoped<IXApiService, XApiService>();


### PR DESCRIPTION
 Summary                                                                                                           
                  
  - Bug fix: Catalog copy now correctly includes all related entities (inject types, data fields, data options,
  injects, and data values) via eager loading with AsSplitQuery(), preventing incomplete copies that were missing
  inject and data content.
  - Feature: Adds real-time user presence tracking to the SignalR MainHub so clients can see who else is viewing a
  MSEL.                                                                                                             
  
  Changes                                                                                                           
                  
  CatalogService.cs — fixes the CopyAsync method to eager-load the full object graph before copying:
  - Includes InjectType → DataFields → DataOptions
  - Includes CatalogInjects → Inject → InjectType 
  - Includes CatalogInjects → Inject → DataValues
  - Uses AsSplitQuery() to avoid cartesian explosion from multiple collection includes
                                                                                      
  HubCache.cs (new) — thread-safe singleton (ConcurrentDictionary) that tracks active SignalR connections keyed by
  connection ID, storing the user's ID, name, and currently selected MSEL.                                          
  
  MainHub.cs — adds presence awareness to the hub:                                                                  
  - SelectMsel: broadcasts PresenceArrived to other MSEL members when a user joins, broadcasts PresenceDeparted when
   switching away from a MSEL
  - Leave / OnDisconnectedAsync: broadcasts PresenceDeparted on explicit leave or unexpected disconnect
  - Greet(mselId): allows a newly connected client to announce itself to others already in the MSEL
  - GetPresence(mselId): returns the list of other users currently viewing a given MSEL

  Startup.cs — registers HubCache as a singleton service.