### PR TITLE
Add automatic xAPI queue cleanup with configurable retention

### DIFF
--- a/Blueprint.Api/Infrastructure/Options/XApiOptions.cs
+++ b/Blueprint.Api/Infrastructure/Options/XApiOptions.cs
@@ -13,5 +13,6 @@ namespace Blueprint.Api.Infrastructure.Options
         public string UiUrl { get; set; }
         public string Platform { get; set; }
         public string EmailDomain { get; set; }
+        public int RetentionDays { get; set; } = 7;
     }
 }

--- a/Blueprint.Api/Services/XApiBackgroundService.cs
+++ b/Blueprint.Api/Services/XApiBackgroundService.cs
@@ -2,6 +2,7 @@
 // Released under a MIT (SEI)-style license, please see LICENSE.md in the project root for license information or contact permission@sei.cmu.edu for full terms.
 
 using System;
+using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
@@ -21,6 +22,7 @@ namespace Blueprint.Api.Services
         private readonly ILogger<XApiBackgroundService> _logger;
         private const int ProcessingDelaySeconds = 5;
         private const int BatchSize = 10;
+        private const int CleanupDelayHours = 24;
 
         public XApiBackgroundService(
             IServiceProvider serviceProvider,
@@ -45,6 +47,8 @@ namespace Blueprint.Api.Services
                 }
             }
 
+            DateTime lastCleanup = DateTime.MinValue;
+
             while (!stoppingToken.IsCancellationRequested)
             {
                 try
@@ -54,6 +58,19 @@ namespace Blueprint.Api.Services
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Error processing xAPI queue");
+                }
+
+                if (DateTime.UtcNow - lastCleanup >= TimeSpan.FromHours(CleanupDelayHours))
+                {
+                    try
+                    {
+                        await CleanupOldStatementsAsync(stoppingToken);
+                        lastCleanup = DateTime.UtcNow;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Error cleaning up old xAPI statements");
+                    }
                 }
 
                 // Wait before processing next batch
@@ -112,6 +129,37 @@ namespace Blueprint.Api.Services
                     _logger.LogError(ex, "Error processing xAPI statement {StatementId}", queuedStatement.Id);
                 }
             }
+        }
+
+        private async Task CleanupOldStatementsAsync(CancellationToken cancellationToken)
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var queueService = scope.ServiceProvider.GetRequiredService<IXApiQueueService>();
+            var xApiOptions = scope.ServiceProvider.GetRequiredService<XApiOptions>();
+
+            var cutoffDate = DateTime.UtcNow.AddDays(-xApiOptions.RetentionDays);
+
+            _logger.LogInformation("Cleaning up xAPI statements older than {CutoffDate} (Retention: {RetentionDays} days)",
+                cutoffDate, xApiOptions.RetentionDays);
+
+            var completedStatements = await queueService.GetOldCompletedStatementsAsync(cutoffDate, cancellationToken);
+            var failedStatements = await queueService.GetOldFailedStatementsAsync(cutoffDate, cancellationToken);
+
+            var totalStatements = completedStatements.Count + failedStatements.Count;
+
+            if (totalStatements == 0)
+            {
+                _logger.LogInformation("No old statements to cleanup");
+                return;
+            }
+
+            var allStatementIds = completedStatements.Select(s => s.Id)
+                .Concat(failedStatements.Select(s => s.Id))
+                .ToList();
+
+            await queueService.DeleteStatementsAsync(allStatementIds, cancellationToken);
+
+            _logger.LogInformation("Deleted {Count} old xAPI statements", totalStatements);
         }
 
         public override Task StopAsync(CancellationToken cancellationToken)

--- a/Blueprint.Api/Services/XApiQueueService.cs
+++ b/Blueprint.Api/Services/XApiQueueService.cs
@@ -20,6 +20,9 @@ namespace Blueprint.Api.Services
         Task MarkCompletedAsync(Guid statementId, CancellationToken ct = default);
         Task MarkFailedAsync(Guid statementId, string errorMessage, CancellationToken ct = default);
         Task<int> GetQueueDepthAsync(CancellationToken ct = default);
+        Task<List<XApiQueuedStatementEntity>> GetOldCompletedStatementsAsync(DateTime cutoffDate, CancellationToken ct = default);
+        Task<List<XApiQueuedStatementEntity>> GetOldFailedStatementsAsync(DateTime cutoffDate, CancellationToken ct = default);
+        Task DeleteStatementsAsync(List<Guid> statementIds, CancellationToken ct = default);
     }
 
     public class XApiQueueService : IXApiQueueService
@@ -121,6 +124,32 @@ namespace Blueprint.Api.Services
         {
             return await _context.XApiQueuedStatements
                 .CountAsync(s => s.Status == XApiQueueStatus.Pending || s.Status == XApiQueueStatus.Processing, ct);
+        }
+
+        public async Task<List<XApiQueuedStatementEntity>> GetOldCompletedStatementsAsync(DateTime cutoffDate, CancellationToken ct = default)
+        {
+            return await _context.XApiQueuedStatements
+                .Where(s => s.Status == XApiQueueStatus.Completed && s.QueuedAt < cutoffDate)
+                .ToListAsync(ct);
+        }
+
+        public async Task<List<XApiQueuedStatementEntity>> GetOldFailedStatementsAsync(DateTime cutoffDate, CancellationToken ct = default)
+        {
+            return await _context.XApiQueuedStatements
+                .Where(s => s.Status == XApiQueueStatus.Failed && s.QueuedAt < cutoffDate)
+                .ToListAsync(ct);
+        }
+
+        public async Task DeleteStatementsAsync(List<Guid> statementIds, CancellationToken ct = default)
+        {
+            var statements = await _context.XApiQueuedStatements
+                .Where(s => statementIds.Contains(s.Id))
+                .ToListAsync(ct);
+
+            _context.XApiQueuedStatements.RemoveRange(statements);
+            await _context.SaveChangesAsync(ct);
+
+            _logger.LogInformation("Deleted {Count} xAPI statements from queue", statements.Count);
         }
     }
 }

--- a/Blueprint.Api/appsettings.json
+++ b/Blueprint.Api/appsettings.json
@@ -69,7 +69,8 @@
     "ApiUrl": "",
     "UiUrl": "",
     "EmailDomain": "",
-    "Platform": ""
+    "Platform": "",
+    "RetentionDays": 7
   },
   "ResourceOwnerAuthorization": {
     "Authority": "http://localhost:8080/realms/crucible",


### PR DESCRIPTION
- Add RetentionDays config to XApiOptions (default 7 days)
- Add cleanup methods to XApiQueueService for retrieving and deleting old statements
- XApiBackgroundService runs cleanup every 24 hours, first run on startup
- Deletes both completed and failed statements after retention period
- Document RetentionDays setting in appsettings.json for discoverability