### PR TITLE
Add IncludeInPlaybook field to MselPage for playbook export

### DIFF
--- a/Blueprint.Api.Data/BlueprintContext.cs
+++ b/Blueprint.Api.Data/BlueprintContext.cs
@@ -22,6 +22,7 @@ namespace Blueprint.Api.Data
     [GenerateEntityEventInterfaces(typeof(INotification))]
     public class BlueprintContext : EventPublishingDbContext
     {
+        public bool SkipEventPublishing { get; set; }
 
         public BlueprintContext(DbContextOptions<BlueprintContext> options) : base(options) { }
 
@@ -96,6 +97,11 @@ namespace Blueprint.Api.Data
 
         public override async Task PublishEventsAsync(IReadOnlyList<IEntityEvent> events, CancellationToken cancellationToken)
         {
+            if (SkipEventPublishing)
+            {
+                return;
+            }
+
             if (ServiceProvider is not null)
             {
                 var mediator = ServiceProvider.GetRequiredService<IMediator>();

--- a/Blueprint.Api.Data/Enumerations.cs
+++ b/Blueprint.Api.Data/Enumerations.cs
@@ -92,7 +92,8 @@ namespace Blueprint.Api.Data.Enumerations
         Email,
         Phone,
         Intel,
-        Reporting
+        Reporting,
+        Orders
     }
 
     public enum SteamfitterTaskAction

--- a/Blueprint.Api.Data/Models/MselPage.cs
+++ b/Blueprint.Api.Data/Models/MselPage.cs
@@ -25,6 +25,7 @@ namespace Blueprint.Api.Data.Models
         public string Content { get; set; }
 
         public bool AllCanView { get; set; }
+        public bool IncludeInPlaybook { get; set; }
     }
 
     public class MselPageConfiguration : IEntityTypeConfiguration<MselPageEntity>

--- a/Blueprint.Api.Migrations.PostgreSQL/Migrations/20260511185347_AddIncludeInPlaybookToMselPages.Designer.cs
+++ b/Blueprint.Api.Migrations.PostgreSQL/Migrations/20260511185347_AddIncludeInPlaybookToMselPages.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Blueprint.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Blueprint.Api.Migrations.PostgreSQL.Migrations
 {
     [DbContext(typeof(BlueprintContext))]
-    partial class BlueprintContextModelSnapshot : ModelSnapshot
+    [Migration("20260511185347_AddIncludeInPlaybookToMselPages")]
+    partial class AddIncludeInPlaybookToMselPages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Blueprint.Api.Migrations.PostgreSQL/Migrations/20260511185347_AddIncludeInPlaybookToMselPages.cs
+++ b/Blueprint.Api.Migrations.PostgreSQL/Migrations/20260511185347_AddIncludeInPlaybookToMselPages.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Blueprint.Api.Migrations.PostgreSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIncludeInPlaybookToMselPages : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "include_in_playbook",
+                table: "msel_pages",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "include_in_playbook",
+                table: "msel_pages");
+        }
+    }
+}

--- a/Blueprint.Api/Services/CardService.cs
+++ b/Blueprint.Api/Services/CardService.cs
@@ -87,7 +87,9 @@ namespace Blueprint.Api.Services
         {
             if (card.MselId.HasValue)
             {
-                if (!hasMselPermission && !await MselOwnerRequirement.IsMet(_user.GetId(), card.MselId, _context))
+                if (!hasMselPermission &&
+                    !await MselOwnerRequirement.IsMet(_user.GetId(), card.MselId, _context) &&
+                    !await MselEditorRequirement.IsMet(_user.GetId(), card.MselId, _context))
                     throw new ForbiddenException();
             }
             else
@@ -110,7 +112,9 @@ namespace Blueprint.Api.Services
         {
             if (card.MselId.HasValue)
             {
-                if (!hasMselPermission && !await MselOwnerRequirement.IsMet(_user.GetId(), card.MselId, _context))
+                if (!hasMselPermission &&
+                    !await MselOwnerRequirement.IsMet(_user.GetId(), card.MselId, _context) &&
+                    !await MselEditorRequirement.IsMet(_user.GetId(), card.MselId, _context))
                     throw new ForbiddenException();
             }
             else
@@ -144,7 +148,9 @@ namespace Blueprint.Api.Services
 
             if (cardToDelete.MselId.HasValue)
             {
-                if (!hasMselPermission && !await MselOwnerRequirement.IsMet(_user.GetId(), cardToDelete.MselId, _context))
+                if (!hasMselPermission &&
+                    !await MselOwnerRequirement.IsMet(_user.GetId(), cardToDelete.MselId, _context) &&
+                    !await MselEditorRequirement.IsMet(_user.GetId(), cardToDelete.MselId, _context))
                     throw new ForbiddenException();
             }
             else

--- a/Blueprint.Api/Services/MselService.cs
+++ b/Blueprint.Api/Services/MselService.cs
@@ -467,7 +467,9 @@ namespace Blueprint.Api.Services
             }
 
             _context.Msels.Add(mselEntity);
+            _context.SkipEventPublishing = true;
             await _context.SaveChangesAsync(ct);
+            _context.SkipEventPublishing = false;
 
             // get the new MSEL to return
             mselEntity = await _context.Msels

--- a/Blueprint.Api/ViewModels/MselPage.cs
+++ b/Blueprint.Api/ViewModels/MselPage.cs
@@ -15,6 +15,7 @@ namespace Blueprint.Api.ViewModels
         public string Name { get; set; }
         public string Content { get; set; }
         public bool AllCanView { get; set; }
+        public bool IncludeInPlaybook { get; set; }
     }
 
 }


### PR DESCRIPTION
  Summary

  Optimizes MSEL copy performance by skipping SignalR event publishing during bulk operations. For large MSELs (742+ entities), copy time reduced from
  hanging/timeout to ~3 seconds.

  Problem

  MSEL copy operations generated hundreds of entity events that triggered SignalR event handlers. Each handler executed expensive database queries (with
  Includes and AsSplitQuery), blocking the HTTP response and causing timeouts for large MSELs.

  Solution

  - Added SkipEventPublishing flag to BlueprintContext
  - MselService.CopyAsync sets flag before SaveChangesAsync to bypass event publishing
  - UI receives complete MSEL data from HTTP 201 response, making real-time SignalR notifications unnecessary
  - Other users won't see new MSEL in real-time, but MSEL creation is typically solo work

  Testing

  - Tested copy of 742-entity MSEL with integrations: completes in ~2.9 seconds with HTTP 201
  - UI correctly displays copied MSEL from response data

✻ Brewed for 26s

❯ pr shoudl include all updates in the branch                                                                                                             

● Bash(git log origin/main..HEAD --oneline)
  ⎿  d879cc0 Skip SignalR event publishing during MSEL copy operations
     c8eca97 Fix CardService to check MselEditorRequirement for card operations
     f71424f Add IncludeInPlaybook field to MselPage for playbook export

● Bash(git log origin/main..HEAD --format="%B" | head -50)
  ⎿  Skip SignalR event publishing during MSEL copy operations

     - Add SkipEventPublishing flag to BlueprintContext
     … +18 lines (ctrl+o to expand)

● ---
  Summary

  Three improvements to Blueprint API: performance optimization for MSEL copy, permissions fix for card operations, and playbook export field addition.

  Changes

  1. Skip SignalR event publishing during MSEL copy operations

  Problem: MSEL copy operations generated hundreds of entity events that triggered SignalR event handlers. Each handler executed expensive database
  queries, blocking the HTTP response and causing timeouts for large MSELs (742+ entities).

  Solution:
  - Added SkipEventPublishing flag to BlueprintContext
  - MselService.CopyAsync sets flag before SaveChangesAsync to bypass event publishing
  - UI receives complete MSEL data from HTTP 201 response, making real-time SignalR notifications unnecessary
  - Reduces copy time from hanging/timeout to ~3 seconds for large MSELs

  2. Fix CardService to check MselEditorRequirement for card operations

  Problem: Users with Editor role could not create, update, or delete gallery cards. CardService only checked MselOwnerRequirement.

  Solution: CardService now checks both Owner and Editor roles (via MselEditorRequirement), consistent with other services like DataValueService.

  3. Add IncludeInPlaybook field to MselPage for playbook export

  - Added IncludeInPlaybook boolean to MselPageEntity and MselPage ViewModel
  - Created migration to add include_in_playbook column to msel_pages table
  - Field defaults to false for existing pages
  - Enables selective page inclusion in playbook exports

  Testing

  - MSEL copy: Tested 742-entity MSEL with integrations, completes in ~2.9 seconds with HTTP 201
  - Card permissions: Verified editors can manage cards
  - Playbook field: Migration applied successfully, field accessible in UI