### PR TITLE
Fix defects found by the Blueprint Playwright suite

### DIFF
--- a/Blueprint.Api/Controllers/MselController.cs
+++ b/Blueprint.Api/Controllers/MselController.cs
@@ -23,15 +23,18 @@ namespace Blueprint.Api.Controllers
     public class MselController : BaseController
     {
         private readonly IMselService _mselService;
+        private readonly IIntegrationNameService _integrationNameService;
         private readonly IBlueprintAuthorizationService _authorizationService;
 
         public MselController(
             IMselService mselService,
             ICiteService citeService,
             IPlayerService playerService,
+            IIntegrationNameService integrationNameService,
             IBlueprintAuthorizationService authorizationService)
         {
             _mselService = mselService;
+            _integrationNameService = integrationNameService;
             _authorizationService = authorizationService;
         }
 
@@ -378,6 +381,29 @@ namespace Blueprint.Api.Controllers
         //
         // Integration Section
         //
+
+        /// <summary>
+        /// Gets the names of the things a MSEL is integrated with
+        /// </summary>
+        /// <remarks>
+        /// Returns the display name of each of the MSEL's associations, read from the application that
+        /// owns it. The browser cannot read these itself — the other applications' APIs do not allow
+        /// the Blueprint UI's origin — so Blueprint reads them on the caller's behalf, forwarding the
+        /// caller's own token. A name is empty when there is no such association, or when the
+        /// application that owns it could not be reached.
+        /// </remarks>
+        /// <param name="id">The id of the Msel</param>
+        /// <param name="ct"></param>
+        /// <returns></returns>
+        [HttpGet("msels/{id}/integrations/names")]
+        [ProducesResponseType(typeof(MselIntegrationNames), (int)HttpStatusCode.OK)]
+        [SwaggerOperation(OperationId = "getMselIntegrationNames")]
+        public async Task<IActionResult> GetIntegrationNames(Guid id, CancellationToken ct)
+        {
+            var hasSystemPermission = await _authorizationService.AuthorizeAsync([SystemPermission.ViewMsels], ct);
+            var names = await _integrationNameService.GetAsync(id, hasSystemPermission, ct);
+            return Ok(names);
+        }
 
         /// <summary>
         /// Push Integrations

--- a/Blueprint.Api/Services/IntegrationNameService.cs
+++ b/Blueprint.Api/Services/IntegrationNameService.cs
@@ -1,0 +1,136 @@
+// Copyright 2026 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Blueprint.Api.ViewModels;
+using Cite.Api.Client;
+using Gallery.Api.Client;
+using Player.Api.Client;
+using Steamfitter.Api.Client;
+
+namespace Blueprint.Api.Services
+{
+    public interface IIntegrationNameService
+    {
+        Task<MselIntegrationNames> GetAsync(Guid mselId, bool hasSystemPermission, CancellationToken ct);
+    }
+
+    /// <summary>
+    /// Resolves the display names of a MSEL's integrations by asking each application for the thing
+    /// the MSEL is associated with.
+    /// </summary>
+    /// <remarks>
+    /// This is why the lookup belongs here and not in the browser: the sibling APIs only allow their
+    /// own UI's origin, so a fetch from the Blueprint UI is blocked by CORS before it is even sent.
+    /// Blueprint's API has no such restriction, and it already forwards the caller's bearer token to
+    /// each client (see ServiceCollectionExtensions.Add*ApiClient), so a name is only ever returned
+    /// to a user who could have read it directly.
+    /// </remarks>
+    public class IntegrationNameService : IIntegrationNameService
+    {
+        private readonly IMselService _mselService;
+        private readonly IPlayerApiClient _playerApiClient;
+        private readonly IGalleryApiClient _galleryApiClient;
+        private readonly ICiteApiClient _citeApiClient;
+        private readonly ISteamfitterApiClient _steamfitterApiClient;
+        private readonly ILogger<IntegrationNameService> _logger;
+
+        public IntegrationNameService(
+            IMselService mselService,
+            IPlayerApiClient playerApiClient,
+            IGalleryApiClient galleryApiClient,
+            ICiteApiClient citeApiClient,
+            ISteamfitterApiClient steamfitterApiClient,
+            ILogger<IntegrationNameService> logger)
+        {
+            _mselService = mselService;
+            _playerApiClient = playerApiClient;
+            _galleryApiClient = galleryApiClient;
+            _citeApiClient = citeApiClient;
+            _steamfitterApiClient = steamfitterApiClient;
+            _logger = logger;
+        }
+
+        public async Task<MselIntegrationNames> GetAsync(Guid mselId, bool hasSystemPermission, CancellationToken ct)
+        {
+            // Getting the MSEL through MselService is what authorizes the caller: it throws
+            // ForbiddenException for a user who cannot view this MSEL, so the names below cannot be
+            // used to read the name of something the caller has no business seeing.
+            var msel = await _mselService.GetAsync(mselId, hasSystemPermission, ct);
+            var names = new MselIntegrationNames();
+            if (msel == null)
+                return names;
+
+            if (msel.PlayerViewId.HasValue)
+            {
+                var id = msel.PlayerViewId.Value;
+                names.PlayerViewName = await ResolveAsync("Player view", id,
+                    async () => (await _playerApiClient.GetViewAsync(id, ct))?.Name, ct);
+            }
+
+            if (msel.GalleryCollectionId.HasValue)
+            {
+                var id = msel.GalleryCollectionId.Value;
+                names.GalleryCollectionName = await ResolveAsync("Gallery collection", id,
+                    async () => (await _galleryApiClient.GetCollectionAsync(id, ct))?.Name, ct);
+            }
+
+            if (msel.GalleryExhibitId.HasValue)
+            {
+                var id = msel.GalleryExhibitId.Value;
+                names.GalleryExhibitName = await ResolveAsync("Gallery exhibit", id,
+                    async () => (await _galleryApiClient.GetExhibitAsync(id, ct))?.Name, ct);
+            }
+
+            if (msel.CiteEvaluationId.HasValue)
+            {
+                // CITE evaluations and scoring models are named by their Description.
+                var id = msel.CiteEvaluationId.Value;
+                names.CiteEvaluationName = await ResolveAsync("CITE evaluation", id,
+                    async () => (await _citeApiClient.GetEvaluationAsync(id, ct))?.Description, ct);
+            }
+
+            if (msel.CiteScoringModelId.HasValue)
+            {
+                var id = msel.CiteScoringModelId.Value;
+                names.CiteScoringModelName = await ResolveAsync("CITE scoring model", id,
+                    async () => (await _citeApiClient.GetScoringModelAsync(id, ct))?.Description, ct);
+            }
+
+            if (msel.SteamfitterScenarioId.HasValue)
+            {
+                var id = msel.SteamfitterScenarioId.Value;
+                names.SteamfitterScenarioName = await ResolveAsync("Steamfitter scenario", id,
+                    async () => (await _steamfitterApiClient.GetScenarioAsync(id, ct))?.Name, ct);
+            }
+
+            return names;
+        }
+
+        /// <summary>
+        /// Runs one name lookup, turning any failure into an empty name.
+        /// </summary>
+        /// <remarks>
+        /// One unreachable application must not cost the caller the other five names, and an
+        /// association whose target has been deleted out from under the MSEL is a display problem
+        /// rather than an error, so a failed lookup is logged and reported as no name at all.
+        /// Cancellation is not a failure and is left to propagate.
+        /// </remarks>
+        private async Task<string> ResolveAsync(string what, Guid id, Func<Task<string>> lookup, CancellationToken ct)
+        {
+            try
+            {
+                return await lookup() ?? "";
+            }
+            // System.Exception is spelled out because both generated clients declare their own.
+            catch (System.Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex, $"Could not resolve the {what} name for {id}.");
+                return "";
+            }
+        }
+    }
+}

--- a/Blueprint.Api/Services/MselService.cs
+++ b/Blueprint.Api/Services/MselService.cs
@@ -705,14 +705,13 @@ namespace Blueprint.Api.Services
                 .ToListAsync(ct);
             var dataTable = await GetMselDataAsync(mselId, scenarioEventList, ct);
 
-            // Track system columns (these don't have DataField/DataValue entities)
-            var systemColumns = new HashSet<string>();
-            if (msel.ShowTimeOnScenarioEventList)
-                systemColumns.Add("Time");
-            if (msel.ShowMoveOnScenarioEventList)
-                systemColumns.Add("Move");
-            if (msel.ShowGroupOnScenarioEventList)
-                systemColumns.Add("Group");
+            // Track system columns (these don't have DataField/DataValue entities). Derived from the
+            // same helper GetMselDataAsync used, so the two views of the sheet cannot disagree.
+            var dataFieldNames = await _context.DataFields
+                .Where(df => df.MselId == mselId)
+                .Select(df => df.Name)
+                .ToListAsync(ct);
+            var systemColumns = GetSystemColumns(msel, dataFieldNames).Select(c => c.Name).ToHashSet();
 
             // create the xlsx file in memory
             MemoryStream memoryStream = new MemoryStream();
@@ -940,24 +939,36 @@ namespace Blueprint.Api.Services
                     await _context.SaveChangesAsync(ct);
                 }
                 // create the data fields
-                CreateDataFields(msel, headerRow, workbookPart, columns);
+                var sheetLayout = CreateDataFields(msel, headerRow, workbookPart, columns);
                 await _context.SaveChangesAsync(ct);
                 // remove the header row from the sheet data before creating the scenario events
                 sheetData.RemoveChild<Row>(headerRow);
                 // create the sceanrio events and data values
-                await CreateScenarioEventsAsync(msel.Id, sheetData, workbookPart, msel.DataFields);
+                await CreateScenarioEventsAsync(msel.Id, sheetData, workbookPart, msel.DataFields, sheetLayout);
             }
             await _context.SaveChangesAsync(ct);
             return msel;
         }
 
-        private void CreateDataFields(MselEntity msel, Row headerRow, WorkbookPart workbookPart, Columns columns)
+        /// <summary>
+        /// Reads the header row, reconciling it with the MSEL's Data Fields, and returns where each
+        /// column ended up. The layout is needed because a sheet's columns are no longer guaranteed
+        /// to line up with Data Field display orders: the export also writes system columns, which
+        /// are part of the sheet but are not Data Fields.
+        /// </summary>
+        private SheetLayout CreateDataFields(MselEntity msel, Row headerRow, WorkbookPart workbookPart, Columns columns)
         {
-            var dataFields = msel.DataFields.ToList();
+            var layout = new SheetLayout();
+            var existingDataFields = msel.DataFields.ToList();
             var displayOrder = 1;
+            var headerColumnIndex = 0;
             var verifyDataFields = msel.DataFields.Count > 0;
             foreach (Cell thecurrentcell in headerRow)
             {
+                headerColumnIndex++;
+                var columnIndex = thecurrentcell.CellReference != null
+                    ? GetColumnIndex(thecurrentcell.CellReference.Value)
+                    : headerColumnIndex;
                 string currentcellvalue = string.Empty;
                 // All DataFields are initialized as String data types
                 // this DataType can changed based on the data values found in this column
@@ -991,6 +1002,21 @@ namespace Blueprint.Api.Services
                 else
                 {
                     currentcellvalue = thecurrentcell.InnerText;
+                }
+
+                // System columns are written by the export but are not Data Fields, so they must not
+                // be turned into one (nor rejected as an unknown heading). They are recognized by
+                // name unless the MSEL already has a Data Field of that name, in which case the
+                // user's own column wins — the export applies the same precedence.
+                var headingName = currentcellvalue.Trim();
+                if (IsSystemColumnName(headingName) && !existingDataFields.Any(df => df.Name.Trim() == headingName))
+                {
+                    if (headingName == SystemColumnTime)
+                    {
+                        layout.TimeColumnIndex = columnIndex;
+                    }
+                    // deliberately does not advance displayOrder — this column is not a Data Field
+                    continue;
                 }
 
                 // get the cell style and save it to the cell metadata and column metadata
@@ -1028,7 +1054,6 @@ namespace Blueprint.Api.Services
                     var columnMetadata = "0.0";
                     if (columns != null)
                     {
-                        var columnIndex = GetColumnIndex(thecurrentcell.CellReference.Value);
                         var column = (Column)columns.ChildElements.FirstOrDefault(ce => columnIndex >= ((Column)ce).Min.Value && columnIndex <= ((Column)ce).Max.Value);
                         columnMetadata = column == null || column.Width == null ? "0.0" : column.Width.Value.ToString();
                     }
@@ -1043,6 +1068,7 @@ namespace Blueprint.Api.Services
                         {
                             throw new DataException($"The xlsx file column heading '{currentcellvalue}' is not in the same order as in the current Data Fields.");
                         }
+                        layout.DataFieldColumns[dataField.Id] = columnIndex;
                     }
                     else
                     {
@@ -1061,10 +1087,13 @@ namespace Blueprint.Api.Services
                             ColumnMetadata = columnMetadata
                         };
                         msel.DataFields.Add(dataField);
+                        layout.DataFieldColumns[dataField.Id] = columnIndex;
                     }
                 }
                 displayOrder++;
             }
+
+            return layout;
         }
 
         private int GetColumnIndex(string columnRef)
@@ -1087,7 +1116,7 @@ namespace Blueprint.Api.Services
             return columnIndex;
         }
 
-        private async Task CreateScenarioEventsAsync(Guid mselId, SheetData dataRows, WorkbookPart workbookPart, ICollection<DataFieldEntity> dataFields)
+        private async Task CreateScenarioEventsAsync(Guid mselId, SheetData dataRows, WorkbookPart workbookPart, ICollection<DataFieldEntity> dataFields, SheetLayout layout)
         {
             foreach (Row dataRow in dataRows)
             {
@@ -1133,20 +1162,34 @@ namespace Blueprint.Api.Services
                 var rowMetadata = dataRow.Height != null ? dataRow.Height.Value.ToString() : "";
                 rowMetadata = rowMetadata + "," + GetTintedColor(cellColor, cellTint);
                 var rowIndex = (int)dataRow.RowIndex.Value - 1;     // header row was index 1
+                // The Time column holds the event's real schedule, so read it back rather than
+                // inventing one — an exported MSEL that is imported again must keep its timings.
+                // Only when the sheet has no usable Time value is there nothing to schedule from,
+                // and then one minute per row at least preserves the order of the rows.
+                var deltaSeconds = rowIndex * 60;
+                if (layout.TimeColumnIndex.HasValue)
+                {
+                    var timeCellReference = GetCellReference(layout.TimeColumnIndex.Value, (int)dataRow.RowIndex.Value);
+                    var timeCell = cells.FirstOrDefault(c => c.CellReference == timeCellReference);
+                    if (TryParseDeltaSeconds(GetCellText(timeCell, workbookPart), out var parsedDeltaSeconds))
+                    {
+                        deltaSeconds = parsedDeltaSeconds;
+                    }
+                }
                 var scenarioEvent = new ScenarioEventEntity()
                 {
                     Id = Guid.NewGuid(),
                     MselId = mselId,
                     ScenarioEventType = EventType.Inject,
-                    DeltaSeconds = rowIndex * 60,    // value of seconds (1 minute) used to maintain the row order
+                    DeltaSeconds = deltaSeconds,
                     RowMetadata = rowMetadata
                 };
                 await _context.ScenarioEvents.AddAsync(scenarioEvent);
-                await CreateDataValuesAsync(scenarioEvent, dataRow, workbookPart, dataFields);
+                await CreateDataValuesAsync(scenarioEvent, dataRow, workbookPart, dataFields, layout);
             }
         }
 
-        private async Task CreateDataValuesAsync(ScenarioEventEntity scenarioEvent, Row dataRow, WorkbookPart workbookPart, ICollection<DataFieldEntity> dataFields)
+        private async Task CreateDataValuesAsync(ScenarioEventEntity scenarioEvent, Row dataRow, WorkbookPart workbookPart, ICollection<DataFieldEntity> dataFields, SheetLayout layout)
         {
             // loop through each DataField
             var cells = dataRow.Elements<Cell>();
@@ -1154,8 +1197,16 @@ namespace Blueprint.Api.Services
             {
                 string currentCellValue = string.Empty;
                 string cellMetadata = ",0,normal," + (int)dataField.DataType;
-                var cellReference = GetCellReference(dataField.DisplayOrder, (int)dataRow.RowIndex.Value);
-                var cell = cells.FirstOrDefault(c => c.CellReference == cellReference);
+                // Use the column this field was actually found in. Its DisplayOrder is an ordering
+                // among Data Fields, which stops matching the spreadsheet column as soon as the
+                // sheet also carries a system column. A field with no column in the sheet keeps the
+                // same outcome as an empty cell: an empty DataValue.
+                Cell cell = null;
+                if (layout.DataFieldColumns.TryGetValue(dataField.Id, out var dataFieldColumnIndex))
+                {
+                    var cellReference = GetCellReference(dataFieldColumnIndex, (int)dataRow.RowIndex.Value);
+                    cell = cells.FirstOrDefault(c => c.CellReference == cellReference);
+                }
                 if (cell != null)
                 {
                     // get the cell format from the style index
@@ -1305,12 +1356,12 @@ namespace Blueprint.Api.Services
             {
                 allColumns.Add((df.Name, df.DisplayOrder, false));
             }
-            if (msel.ShowTimeOnScenarioEventList)
-                allColumns.Add(("Time", msel.TimeDisplayOrder, true));
-            if (msel.ShowMoveOnScenarioEventList)
-                allColumns.Add(("Move", msel.MoveDisplayOrder, true));
-            if (msel.ShowGroupOnScenarioEventList)
-                allColumns.Add(("Group", msel.GroupDisplayOrder, true));
+            var systemColumns = GetSystemColumns(msel, dataFieldList.Select(df => df.Name).ToList());
+            foreach (var systemColumn in systemColumns)
+            {
+                allColumns.Add((systemColumn.Name, systemColumn.DisplayOrder, true));
+            }
+            var systemColumnNames = systemColumns.Select(c => c.Name).ToHashSet();
             allColumns = allColumns.OrderBy(c => c.DisplayOrder).ToList();
 
             foreach (var col in allColumns)
@@ -1357,23 +1408,151 @@ namespace Blueprint.Api.Services
                     dataRow[dataValue.Name] = displayValue;
                 }
                 // Populate system columns
-                if (msel.ShowTimeOnScenarioEventList)
+                if (systemColumnNames.Contains(SystemColumnTime))
                 {
-                    dataRow["Time"] = FormatDeltaSeconds(scenarioEvent.DeltaSeconds);
+                    dataRow[SystemColumnTime] = FormatDeltaSeconds(scenarioEvent.DeltaSeconds);
                 }
-                if (msel.ShowMoveOnScenarioEventList && moveAndGroupNumbers.ContainsKey(scenarioEvent.Id))
+                if (systemColumnNames.Contains(SystemColumnMove) && moveAndGroupNumbers.ContainsKey(scenarioEvent.Id))
                 {
                     var moveNumber = moveAndGroupNumbers[scenarioEvent.Id].Item1;
-                    dataRow["Move"] = moveNumber >= 0 ? moveNumber.ToString() : "";
+                    dataRow[SystemColumnMove] = moveNumber >= 0 ? moveNumber.ToString() : "";
                 }
-                if (msel.ShowGroupOnScenarioEventList && moveAndGroupNumbers.ContainsKey(scenarioEvent.Id))
+                if (systemColumnNames.Contains(SystemColumnGroup) && moveAndGroupNumbers.ContainsKey(scenarioEvent.Id))
                 {
-                    dataRow["Group"] = moveAndGroupNumbers[scenarioEvent.Id].Item2.ToString();
+                    dataRow[SystemColumnGroup] = moveAndGroupNumbers[scenarioEvent.Id].Item2.ToString();
                 }
                 dataTable.Rows.Add(dataRow);
             }
 
             return dataTable;
+        }
+
+        // Columns the xlsx carries that are not Data Fields. Both the export and the import key off
+        // these names, so they have to agree — hence the constants.
+        private const string SystemColumnTime = "Time";
+        private const string SystemColumnMove = "Move";
+        private const string SystemColumnGroup = "Group";
+
+        private static bool IsSystemColumnName(string name) =>
+            name == SystemColumnTime || name == SystemColumnMove || name == SystemColumnGroup;
+
+        /// <summary>
+        /// The system columns to write into an exported sheet, with the display order each takes
+        /// among the Data Field columns.
+        /// </summary>
+        /// <remarks>
+        /// Time is always written. It is the only system column whose value cannot be recomputed
+        /// from the sheet — Move and Group are derived from the events' own ordering — so omitting
+        /// it makes an export/import round trip silently lose every event's schedule. Move and
+        /// Group stay opt-in, as before.
+        ///
+        /// A Data Field of the same name takes precedence: it is the user's own column, and
+        /// DataTable throws on a duplicate column name. The import applies the same precedence, so
+        /// a MSEL whose fields shadow a system name round-trips as plain Data Fields.
+        /// </remarks>
+        private static List<(string Name, int DisplayOrder)> GetSystemColumns(MselEntity msel, ICollection<string> dataFieldNames)
+        {
+            var takenNames = dataFieldNames.Select(n => n == null ? string.Empty : n.Trim()).ToHashSet();
+            var systemColumns = new List<(string Name, int DisplayOrder)>();
+            if (!takenNames.Contains(SystemColumnTime))
+                systemColumns.Add((SystemColumnTime, msel.TimeDisplayOrder));
+            if (msel.ShowMoveOnScenarioEventList && !takenNames.Contains(SystemColumnMove))
+                systemColumns.Add((SystemColumnMove, msel.MoveDisplayOrder));
+            if (msel.ShowGroupOnScenarioEventList && !takenNames.Contains(SystemColumnGroup))
+                systemColumns.Add((SystemColumnGroup, msel.GroupDisplayOrder));
+            return systemColumns;
+        }
+
+        /// <summary>
+        /// Reads a Time column value back into seconds — the inverse of <see cref="FormatDeltaSeconds"/>.
+        /// Anything that is not in that format is refused rather than guessed at, leaving the caller
+        /// to fall back to row order.
+        /// </summary>
+        private static bool TryParseDeltaSeconds(string value, out int deltaSeconds)
+        {
+            deltaSeconds = 0;
+            if (string.IsNullOrWhiteSpace(value))
+                return false;
+
+            var text = value.Trim();
+            var sign = 1;
+            if (text.StartsWith("-"))
+            {
+                sign = -1;
+                text = text.Substring(1).Trim();
+            }
+            else if (text.StartsWith("+"))
+            {
+                text = text.Substring(1).Trim();
+            }
+
+            // an optional leading day count, as written for anything a day or more out
+            var days = 0;
+            var parts = text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 2)
+            {
+                if (!int.TryParse(parts[0], out days) || days < 0)
+                    return false;
+                text = parts[1];
+            }
+            else if (parts.Length == 1)
+            {
+                text = parts[0];
+            }
+            else
+            {
+                return false;
+            }
+
+            var hoursMinutesSeconds = text.Split(':');
+            if (hoursMinutesSeconds.Length != 3)
+                return false;
+            if (!int.TryParse(hoursMinutesSeconds[0], out var hours) || hours < 0)
+                return false;
+            if (!int.TryParse(hoursMinutesSeconds[1], out var minutes) || minutes < 0)
+                return false;
+            if (!int.TryParse(hoursMinutesSeconds[2], out var seconds) || seconds < 0)
+                return false;
+
+            var total = (long)days * 86400 + (long)hours * 3600 + (long)minutes * 60 + seconds;
+            if (total > int.MaxValue)
+                return false;
+
+            deltaSeconds = sign * (int)total;
+            return true;
+        }
+
+        /// <summary>
+        /// The text of a cell, resolving the shared string table. Enough for the system columns,
+        /// which are always written as plain strings.
+        /// </summary>
+        private static string GetCellText(Cell cell, WorkbookPart workbookPart)
+        {
+            if (cell == null)
+                return string.Empty;
+
+            if (cell.DataType != null && cell.DataType == CellValues.SharedString &&
+                int.TryParse(cell.InnerText, out var sharedStringId) &&
+                workbookPart.SharedStringTablePart != null)
+            {
+                var item = workbookPart.SharedStringTablePart.SharedStringTable
+                    .Elements<SharedStringItem>().ElementAtOrDefault(sharedStringId);
+                if (item == null)
+                    return string.Empty;
+                return item.Text != null ? item.Text.Text : item.InnerText;
+            }
+
+            return cell.CellValue != null ? cell.CellValue.Text : cell.InnerText;
+        }
+
+        /// <summary>
+        /// Where each column of an imported sheet ended up, so values can be read from the column a
+        /// heading was actually found in rather than from an assumed position.
+        /// </summary>
+        private sealed class SheetLayout
+        {
+            public Dictionary<Guid, int> DataFieldColumns { get; } = new Dictionary<Guid, int>();
+            public int? TimeColumnIndex { get; set; }
         }
 
         private string FormatDeltaSeconds(int deltaSeconds)

--- a/Blueprint.Api/Startup.cs
+++ b/Blueprint.Api/Startup.cs
@@ -201,6 +201,7 @@ public class Startup
         services.AddScoped<IScenarioEventService, ScenarioEventService>();
         services.AddScoped<IInjectService, InjectService>();
         services.AddScoped<IInjectTypeService, InjectTypeService>();
+        services.AddScoped<IIntegrationNameService, IntegrationNameService>();
         services.AddScoped<IInvitationService, InvitationService>();
         services.AddScoped<IInjectTypeService, InjectTypeService>();
         services.AddScoped<IMselService, MselService>();

--- a/Blueprint.Api/ViewModels/Msel.cs
+++ b/Blueprint.Api/ViewModels/Msel.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using Blueprint.Api.Data.Enumerations;
 
 namespace Blueprint.Api.ViewModels
@@ -10,6 +11,11 @@ namespace Blueprint.Api.ViewModels
     public class Msel : Base
     {
         public Guid Id { get; set; }
+
+        // A MSEL must be named. Required rejects null, "" and whitespace-only values (it trims
+        // before testing), which ValidateModelStateFilter turns into a 400 for both createMsel
+        // and updateMsel — the only two endpoints that bind a Msel from the request body.
+        [Required]
         public string Name { get; set; }
         public string Description { get; set; }
         public MselItemStatus Status { get; set; }
@@ -30,6 +36,11 @@ namespace Blueprint.Api.ViewModels
         public IntegrationType SteamfitterIntegrationType { get; set; }
         public bool IsTemplate { get; set; }
         public DateTime StartTime { get; set; }
+
+        // The exercise window is stored as StartTime plus a duration, so an end time that precedes
+        // the start is exactly a negative DurationSeconds. Zero stays legal — it means no window
+        // has been set yet.
+        [Range(0, int.MaxValue, ErrorMessage = "The exercise duration cannot be negative; the end time must not precede the start time.")]
         public int DurationSeconds { get; set; }
         public bool ShowTimeOnScenarioEventList { get; set; }
         public bool ShowTimeOnExerciseView { get; set; }

--- a/Blueprint.Api/ViewModels/MselIntegrationNames.cs
+++ b/Blueprint.Api/ViewModels/MselIntegrationNames.cs
@@ -1,0 +1,24 @@
+// Copyright 2026 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license, please see LICENSE.md in the project root for license information or contact permission@sei.cmu.edu for full terms.
+
+namespace Blueprint.Api.ViewModels
+{
+    /// <summary>
+    /// The display names of the things a MSEL is integrated with.
+    /// </summary>
+    /// <remarks>
+    /// The ids of those things are on the Msel itself; only their names live here, because a name has
+    /// to be read from the application that owns it. A name is empty when the MSEL has no association
+    /// of that kind, or when that application could not be reached — the association is still valid in
+    /// that case, so the name is best-effort and never fails the request.
+    /// </remarks>
+    public class MselIntegrationNames
+    {
+        public string PlayerViewName { get; set; } = "";
+        public string GalleryCollectionName { get; set; } = "";
+        public string GalleryExhibitName { get; set; } = "";
+        public string CiteEvaluationName { get; set; } = "";
+        public string CiteScoringModelName { get; set; } = "";
+        public string SteamfitterScenarioName { get; set; } = "";
+    }
+}


### PR DESCRIPTION
Four defects in Blueprint.Api, all found by crucible-tests/blueprint. Three are validation or round-trip bugs; the fourth is a new endpoint that lets the UI read integration names it cannot fetch itself.

**`name` was not required** (`ViewModels/Msel.cs`)

`PUT /api/msels/{id}` and `POST /api/msels` accepted `name: ""`, `"   "` and `null`, so the required-name rule lived in the browser alone and any other client could persist a nameless MSEL. `Name` now carries `[Required]`, which trims before testing and so rejects whitespace-only names too — the same rule as the UI's `pattern=".*\S.*"`. The already-registered `ValidateModelStateFilter` turns that into a **400** (`Invalid Data` / `Name: The Name field is required.`); an `ArgumentException` in `MselService`, which is the convention used elsewhere, would instead have produced a 500, because `JsonExceptionFilter` maps only `IApiException` to a status code. Validating at the binding layer covers exactly the two endpoints that bind a `Msel` from the body (`MselController.Create` and `.Update`); the xlsx-upload, copy and catalog paths build entities internally and are deliberately untouched, and no other view model has a `Msel`-typed property, so nothing else picks the rule up recursively.

**A MSEL's exercise window could end before it started** (`ViewModels/Msel.cs`)

`PUT /api/msels/{id}` accepted `durationSeconds: -86400` and persisted it verbatim. Blueprint stores the window as `StartTime` plus `DurationSeconds`, so a negative duration *is* an end time before the start, and there was no range check at either layer. `DurationSeconds` now carries `[Range(0, int.MaxValue, …)]`, which the same filter turns into a 400. Zero stays legal: it means no window has been set yet, which is what `POST /api/msels` produces. The wire format is a red herring — `JsonIntegerConverter` writes every `int` as a JSON string and reads back both forms, but `[Range]` validates the bound `int` after conversion, so it applies however the client sent the value.

**An xlsx round-trip destroyed every scenario event's schedule** (`Services/MselService.cs`)

Reported as export-then-import rewriting the delivery offsets `[300, 900]` to `[60, 120]`. That understated it: there were three separate defects, and fixing only the parsing would have exposed the other two.

1. **The export never wrote the schedule at all.** Time is a *system* column, emitted only when `ShowTimeOnScenarioEventList` is true, and that flag defaults to false — so a MSEL created through `POST /api/msels` exported a workbook whose header row was exactly the 13 standard Data Fields. The import's `deltaSeconds = rowIndex * 60` was not misparsing a time; it had nothing to parse.
2. **A workbook that did contain a Time column could not be imported.** With the flag set, re-importing Blueprint's own export returned 500: "The xlsx file column heading 'Time' does not exist in the current Data Fields." `CreateDataFields` knew nothing about system columns and rejected the export's own output as an unknown heading.
3. **Export crashed when a system column's name was already taken by a Data Field.** With `ShowMoveOnScenarioEventList` set and a Data Field also named "Move", `GetMselDataAsync` threw 500 "A column named 'Move' already belongs to this DataTable." The standard 13-field set contains both "Move" and "Group", so this was easy to hit — and would have become a *new* regression the moment Time was always added.

The fix treats the sheet layout as one model rather than patching the parse:

- `GetSystemColumns(msel, dataFieldNames)` is the single source of truth for which system columns a sheet carries. Time is now always included — it is the only system column that cannot be recomputed from the entities, whereas Move and Group can and stay flag-gated. Any system column whose name a Data Field already claims is dropped, so the user's own column wins. Both `GetMselDataAsync` and `DownloadXlsxAsync` derive from this helper, so the two views of the sheet cannot disagree.
- On import, `CreateDataFields` recognises Time/Move/Group by name (subject to the same Data-Field precedence) and skips them instead of erroring, without advancing `DisplayOrder` — they are not Data Fields.
- `CreateDataFields` now returns a `SheetLayout` (`DataField.Id` to real column index, plus `TimeColumnIndex`), threaded through `CreateScenarioEventsAsync` into `CreateDataValuesAsync`. This replaces the assumption that `DataField.DisplayOrder` *is* the spreadsheet column index — true only until a sheet carries a system column, after which every value was read one column to the left.
- `TryParseDeltaSeconds` is a strict inverse of the existing `FormatDeltaSeconds` (`+ HH:MM:SS` / `+ D HH:MM:SS`, which is lossless). `rowIndex * 60` survives only as the fallback for a sheet with no usable Time value, where it at least preserves row order.

**Visible behaviour change:** every exported workbook now contains a Time column, whether or not `ShowTimeOnScenarioEventList` is set. That is what makes the round trip lossless, but anyone diffing exports against a previous release will see the extra column.

**No integration name could ever render in the UI** (new `Services/IntegrationNameService.cs`, `ViewModels/MselIntegrationNames.cs`, `MselController`, `Startup`)

The UI resolved its six integration names — Player view, Gallery collection and exhibit, CITE evaluation and scoring model, Steamfitter scenario — with `HttpClient` GETs straight from the browser to those four APIs. Each of them allows only its own UI's origin, so every preflight came back without `Access-Control-Allow-*` headers and the browser discarded the response; no name ever appeared and nothing logged a recognisable error. Adding the Blueprint UI's origin to four sibling services' CORS lists would spread one app's deployment detail across four repos, so Blueprint's API resolves the names instead, via `GET /api/msels/{id}/integrations/names` (`operationId: getMselIntegrationNames`).

- Authorization comes from reaching the MSEL through `MselService.GetAsync`: a user who cannot view it gets `ForbiddenException` before any lookup runs.
- Each lookup is individually try/caught, so one unreachable service costs one name rather than six, and an association whose target has been deleted degrades to an empty name instead of an error. `OperationCanceledException` still propagates.
- This leaks nothing and needs no new service account: the four `Add*ApiClient` registrations forward the caller's own bearer token, so a name comes back only to someone who could have read it directly. `CiteController`/`CiteService` already proxied CITE scoring models this way, so the shape is not new.

