### PR TITLE
Pin a full SDK version in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0",
+    "version": "10.0.100",
     "allowPrerelease": false,
     "rollForward": "latestMinor"
   }


### PR DESCRIPTION
10.0.0 and 10.0 are not full SDK versions - the feature band lives in the patch position, so the first .NET 10 SDK is 10.0.100. The dotnet muxer tolerates the short form because rollForward: latestMinor resolves an installed SDK regardless, which is why local builds are green either way. actions/setup-dotnet rejects it outright:

  Error: Version 10.0.0 is not valid for the sdk.version value in
  global.json. When rollForward is specified, a full SDK version is
  required.

No workflow in this repo feeds global.json to setup-dotnet today, so nothing is failing yet - it fails the moment one does, which is what happened in vm.api. This matches the fix player.api already carries (6627d6e).